### PR TITLE
feat(skills): add slash commands for common workflows

### DIFF
--- a/.claude/commands/new-component.md
+++ b/.claude/commands/new-component.md
@@ -1,0 +1,20 @@
+Create a new UI component named $ARGUMENTS.
+
+Steps:
+1. Create `src/components/ui/$ARGUMENTS.tsx` with:
+   - Proper TypeScript types
+   - forwardRef pattern
+   - cva for variants (if applicable)
+   - cn() for className merging
+   - Export from the file
+2. Add export to `src/components/ui/index.ts`
+3. Create `src/components/ui/__tests__/$ARGUMENTS.test.tsx` with:
+   - Default render test
+   - Variant tests (if applicable)
+   - Event handler tests
+   - Accessibility checks
+4. Add component section to `src/app/showcase/page.tsx`
+5. Run `pnpm test:unit` to verify tests pass
+6. Run `pnpm typecheck` to verify types
+
+Follow existing component patterns in `src/components/ui/button.tsx` as reference.

--- a/.claude/commands/pr-ready.md
+++ b/.claude/commands/pr-ready.md
@@ -1,0 +1,13 @@
+Prepare the current work for a pull request:
+
+1. Run full verification: typecheck, lint, unit tests, integration tests, build
+2. If anything fails, fix it
+3. Stage all changes: `git add -A`
+4. Create a descriptive commit message based on the changes
+5. Push to the current branch
+6. Open a PR using `gh pr create` with:
+   - Clear title
+   - Summary of changes
+   - Test plan
+   - Link to related issue
+7. Report the PR URL

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,6 +1,10 @@
 Run the full verification pipeline for this project:
+
 1. TypeScript type checking: `pnpm typecheck`
-2. Lint: `pnpm lint`
+2. Lint and format check: `pnpm lint`
 3. Unit tests: `pnpm test:unit`
-4. Build: `pnpm build`
-Report results for each step. If any step fails, stop and report the failure.
+4. Integration tests: `pnpm test:integration`
+5. Build check: `pnpm build`
+
+Run each step. If any step fails, stop and report the failure with details.
+If all steps pass, report a summary of results.


### PR DESCRIPTION
## Summary
- Updated `/verify` slash command to include integration tests step and clearer failure/success reporting instructions
- Created `/new-component` slash command that scaffolds a full UI component with types, tests, and showcase entry
- Created `/pr-ready` slash command that automates the full PR preparation workflow (verify → commit → push → PR)

Closes #18

## Test plan
- [x] Run `/verify` in a Claude session — confirm it runs all 5 steps (typecheck, lint, unit tests, integration tests, build)
- [x] Run `/new-component TestComp` — confirm it scaffolds component, tests, and showcase entry
- [x] Run `/pr-ready` — confirm it runs verification, commits, pushes, and creates a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)