### PR TITLE
feat(skills): add frontend tech stack skill

### DIFF
--- a/.claude/skills/frontend-stack/SKILL.md
+++ b/.claude/skills/frontend-stack/SKILL.md
@@ -1,0 +1,135 @@
+---
+description: Next.js 15 + React 19 + Tailwind v4 patterns for this project
+globs:
+  - "src/**/*.tsx"
+  - "src/**/*.ts"
+  - "tailwind.config.*"
+  - "src/app/globals.css"
+---
+
+# Frontend Stack Patterns
+
+## Next.js 15 App Router
+- Default to Server Components (no "use client" unless needed)
+- Use "use client" only for: event handlers, useState/useEffect, browser APIs
+- Layouts in `layout.tsx` — shared UI that doesn't re-render on navigation
+- Pages in `page.tsx` — unique UI for each route
+- Loading states in `loading.tsx`
+- Error boundaries in `error.tsx` (must be client component)
+- Route handlers in `route.ts` for API endpoints
+
+## React 19
+- Server Actions for form mutations (no API routes needed)
+- `use()` for reading promises and context in render
+- `useTransition` for non-blocking state updates
+- `useOptimistic` for optimistic UI updates
+
+## Tailwind v4
+- CSS-first config via `@theme inline` in `src/app/globals.css`
+- No `tailwind.config.ts` — all customization lives in CSS
+- Design tokens defined as CSS custom properties in `:root` and `.dark`
+- Token mapping: `@theme inline` maps `--color-*` vars → Tailwind utilities
+- Use semantic color classes: `bg-primary`, `text-muted-foreground`, `border-border`
+- Responsive: mobile-first with `sm:`, `md:`, `lg:` prefixes
+- Dark mode via `.dark` class (managed by `next-themes`)
+
+### Design Token Colors
+Light `:root` / Dark `.dark` tokens:
+`--background`, `--foreground`, `--card`, `--card-foreground`,
+`--popover`, `--popover-foreground`, `--primary`, `--primary-foreground`,
+`--secondary`, `--secondary-foreground`, `--muted`, `--muted-foreground`,
+`--accent`, `--accent-foreground`, `--destructive`, `--destructive-foreground`,
+`--border`, `--input`, `--ring`
+
+### Fonts
+- `--font-sans` → Geist Sans (body text)
+- `--font-mono` → Geist Mono (code)
+- `--font-display` → Space Grotesk (headings)
+
+## Component Conventions
+- All components in `src/components/ui/`
+- Barrel export from `src/components/ui/index.ts`
+- Use `cva` (class-variance-authority) for variant management
+- Use `cn()` from `src/lib/utils.ts` for class merging (clsx + tailwind-merge)
+- Always use `forwardRef` and accept `className` prop
+- Always set `displayName` on forwardRef components
+- Types exported alongside components (e.g., `ButtonProps`)
+
+### CVA Component Pattern
+```tsx
+import { cva, type VariantProps } from "class-variance-authority";
+import { type ButtonHTMLAttributes, forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva("base-classes...", {
+  variants: {
+    variant: { primary: "...", secondary: "..." },
+    size: { sm: "...", md: "...", lg: "..." },
+  },
+  defaultVariants: { variant: "primary", size: "md" },
+});
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants>;
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };
+export type { ButtonProps };
+```
+
+### Compound Component Pattern (no cva)
+For components with sub-parts (Card, Dialog), use composition:
+```tsx
+import * as React from "react";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className = "", ...props }, ref) => (
+    <div
+      ref={ref}
+      className={["rounded-xl border border-border bg-card text-card-foreground shadow-sm", className]
+        .filter(Boolean)
+        .join(" ")}
+      {...props}
+    />
+  ),
+);
+Card.displayName = "Card";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };
+```
+
+### Radix UI Integration
+Complex interactive components (Avatar, Dialog) use Radix UI primitives:
+- `@radix-ui/react-avatar` for Avatar
+- `@radix-ui/react-dialog` for Dialog
+- `@radix-ui/react-slot` for polymorphic components
+
+## Existing Components
+| Component | Type | Variants |
+|-----------|------|----------|
+| Button | CVA | primary, secondary, outline, ghost, destructive × sm, md, lg |
+| Badge | CVA | default, success, warning, error, info |
+| Avatar | CVA + Radix | sm, md, lg (with image + initials fallback) |
+| Card | Compound | Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter |
+| Dialog | Compound + Radix | Dialog, DialogTrigger, DialogContent, DialogOverlay, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogClose, DialogPortal |
+| Input | Simple | label, error message support |
+
+## Testing
+- Unit tests co-located: `src/components/ui/__tests__/`
+- Use Vitest + React Testing Library
+- E2E tests: `tests/e2e/`
+- Visual regression: `tests/visual/`
+
+## Key Utilities
+- `cn()` in `src/lib/utils.ts` — merges Tailwind classes with conflict resolution
+- Design tokens in `src/lib/tokens.ts` — typed token definitions for the design system


### PR DESCRIPTION
## Summary
- Creates `.claude/skills/frontend-stack/SKILL.md` — a Claude Code skill that provides deep contextual guidance about the project's frontend stack
- Activates automatically when editing `src/**/*.tsx`, `src/**/*.ts`, `tailwind.config.*`, or `src/app/globals.css`
- Documents project-specific patterns: Next.js 15 App Router conventions, React 19 features, Tailwind v4 CSS-first configuration, CVA component pattern, compound component pattern, Radix UI integration, design tokens, and testing structure

## What the skill covers
- **Next.js 15 App Router**: Server/Client component guidance, file conventions (layout, page, loading, error, route)
- **React 19**: Server Actions, `use()`, `useTransition`, `useOptimistic`
- **Tailwind v4**: `@theme inline` config, CSS custom property tokens, semantic color classes, dark mode
- **Component conventions**: CVA variant pattern, compound composition pattern, `forwardRef` + `className` + `displayName`, `cn()` utility
- **Existing component inventory**: Button, Badge, Avatar, Card, Dialog, Input with their variant details
- **Testing structure**: Vitest + RTL (unit), Playwright (E2E + visual regression)

Closes #16

## Test plan
- [x] Open a Claude session in this repo and edit a `.tsx` file — verify the skill context is available
- [x] Confirm glob patterns match expected files (`src/**/*.tsx`, `src/**/*.ts`, etc.)
- [x] Verify SKILL.md frontmatter parses correctly (description + globs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)