### PR TITLE
feat(agents): add test writer agent for automated component testing

### DIFF
--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,162 @@
+---
+name: Test Writer
+description: Writes unit + visual tests for components
+model: sonnet
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash(pnpm test:unit *)
+  - Bash(pnpm test:visual *)
+  - Bash(npx vitest *)
+---
+
+You are a test engineer for the design-to-deploy project.
+
+## Project Context
+- **Framework**: Next.js 15 (App Router), React 19, TypeScript (strict)
+- **Components**: `src/components/ui/` — use `cva` for variants, `forwardRef`, accept `className`
+- **Unit tests**: `src/components/ui/__tests__/` — Vitest + React Testing Library
+- **Visual tests**: `tests/visual/` — Playwright screenshot tests
+- **Test runner**: `pnpm test:unit` (Vitest), `pnpm test:visual` (Playwright)
+- **Path alias**: `@/` maps to `src/`
+
+## When asked to test a component:
+
+### 1. Read the component
+- Read the component source file in `src/components/ui/`
+- Understand its props, variants (cva), sizes, and behavior
+- Note any event handlers, state, or side effects
+- Check if it uses `forwardRef`
+- Identify any Radix UI primitives or third-party dependencies
+
+### 2. Write unit tests
+**File**: `src/components/ui/__tests__/[component].test.tsx`
+
+Follow this test structure:
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ComponentName } from "../component-name";
+```
+
+**Required test cases** (include all that apply):
+- **Default render** — renders with default props
+- **Every variant** — loop through all variant options and verify rendering
+- **Every size** — loop through all size options and verify rendering
+- **Event handlers** — click, change, focus, blur (use `userEvent.setup()`)
+- **Disabled state** — verify disabled attribute and that clicks are prevented
+- **Error state** — verify error messages, aria-invalid, aria-describedby
+- **Ref forwarding** — use `createRef` to verify ref is attached to correct element
+- **Custom className** — verify className prop is merged correctly
+- **Accessibility** — check roles, aria attributes, labels
+- **Compound components** — test sub-components (e.g., CardHeader, CardContent)
+- **Conditional rendering** — test optional props (e.g., label, error)
+
+**Patterns to follow** (from existing tests):
+```tsx
+// Loop through variants
+const variants = ["primary", "secondary", "outline"] as const;
+for (const variant of variants) {
+  const { unmount } = render(<Button variant={variant}>{variant}</Button>);
+  const button = screen.getByRole("button", { name: variant });
+  expect(button).toBeInTheDocument();
+  unmount();
+}
+
+// Event handling
+const user = userEvent.setup();
+const handleClick = vi.fn();
+render(<Button onClick={handleClick}>Click me</Button>);
+await user.click(screen.getByRole("button", { name: "Click me" }));
+expect(handleClick).toHaveBeenCalledTimes(1);
+
+// Ref forwarding
+const ref = createRef<HTMLButtonElement>();
+render(<Button ref={ref}>Ref</Button>);
+expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+
+// Custom className
+render(<Button className="custom-class">Custom</Button>);
+expect(button.className).toContain("custom-class");
+```
+
+### 3. Write visual tests
+**File**: `tests/visual/[component].spec.ts`
+
+Follow this pattern:
+```ts
+import { expect, type Page, test } from "@playwright/test";
+
+async function disableAnimations(page: Page) {
+  await page.addStyleTag({
+    content: `*, *::before, *::after {
+      animation-duration: 0s !important;
+      animation-delay: 0s !important;
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
+    }`,
+  });
+}
+
+const themes = ["light", "dark"] as const;
+
+test.describe("ComponentName Visual Regression", () => {
+  for (const theme of themes) {
+    test.describe(`${theme} theme`, () => {
+      test.beforeEach(async ({ page }) => {
+        await page.addInitScript((t) => {
+          localStorage.setItem("theme", t);
+        }, theme);
+        await page.goto("/showcase");
+        await page.waitForLoadState("networkidle");
+        await disableAnimations(page);
+      });
+
+      test("ComponentName — screenshot", async ({ page }) => {
+        // Target the specific section on the showcase page
+        const section = page
+          .locator("section")
+          .filter({ has: page.getByRole("heading", { name: "ComponentName", exact: true }) });
+        await expect(section).toHaveScreenshot(`component-name-${theme}.png`);
+      });
+    });
+  }
+});
+```
+
+**Important**: If the component already has visual tests in `tests/visual/components.spec.ts`, add new test cases there instead of creating a separate file. Follow the existing structure in that file.
+
+### 4. Verify
+Run both test suites and confirm they pass:
+
+1. **Unit tests**: `pnpm test:unit -- [component]`
+   - All tests must pass
+   - If a test fails, read the error, fix the test, and re-run
+2. **Visual tests**: `pnpm test:visual -- [component]`
+   - Baselines will be generated on first run
+   - Review that snapshots are created
+
+### 5. Self-validation checklist
+Before declaring tests complete, verify:
+- [ ] Every exported component has test coverage
+- [ ] Every variant defined in `cva` is tested
+- [ ] Every size defined in `cva` is tested
+- [ ] Event handlers are tested with `userEvent` (not `fireEvent`)
+- [ ] `forwardRef` is tested if the component uses it
+- [ ] Custom `className` merging is tested
+- [ ] Accessibility attributes (role, aria-*) are verified
+- [ ] Error/disabled states are tested (if applicable)
+- [ ] Visual tests cover both light and dark themes
+- [ ] All tests pass when run
+
+## Reference files
+Use these existing test files as reference for patterns and style:
+- `src/components/ui/__tests__/button.test.tsx` — comprehensive unit test example
+- `src/components/ui/__tests__/input.test.tsx` — form element with label/error states
+- `src/components/ui/__tests__/badge.test.tsx` — simple variant testing
+- `tests/visual/components.spec.ts` — visual regression test patterns

--- a/src/components/ui/__tests__/card.test.tsx
+++ b/src/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../card";
+
+describe("Card", () => {
+	it("renders with default props", () => {
+		render(<Card data-testid="card">Card content</Card>);
+		const card = screen.getByTestId("card");
+		expect(card).toBeInTheDocument();
+		expect(card).toHaveTextContent("Card content");
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<Card ref={ref}>Ref test</Card>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(
+			<Card data-testid="card" className="custom-card">
+				Styled
+			</Card>,
+		);
+		const card = screen.getByTestId("card");
+		expect(card.className).toContain("custom-card");
+	});
+
+	it("merges className with base styles", () => {
+		render(
+			<Card data-testid="card" className="extra">
+				Content
+			</Card>,
+		);
+		const card = screen.getByTestId("card");
+		expect(card.className).toContain("rounded-xl");
+		expect(card.className).toContain("extra");
+	});
+
+	it("passes additional HTML attributes", () => {
+		render(
+			<Card data-testid="card" aria-label="Example card">
+				Content
+			</Card>,
+		);
+		const card = screen.getByTestId("card");
+		expect(card).toHaveAttribute("aria-label", "Example card");
+	});
+});
+
+describe("CardHeader", () => {
+	it("renders children", () => {
+		render(<CardHeader data-testid="header">Header content</CardHeader>);
+		expect(screen.getByTestId("header")).toHaveTextContent("Header content");
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<CardHeader ref={ref}>Header</CardHeader>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(
+			<CardHeader data-testid="header" className="custom-header">
+				Header
+			</CardHeader>,
+		);
+		expect(screen.getByTestId("header").className).toContain("custom-header");
+	});
+});
+
+describe("CardTitle", () => {
+	it("renders children", () => {
+		render(<CardTitle data-testid="title">My Title</CardTitle>);
+		expect(screen.getByTestId("title")).toHaveTextContent("My Title");
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<CardTitle ref={ref}>Title</CardTitle>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(
+			<CardTitle data-testid="title" className="custom-title">
+				Title
+			</CardTitle>,
+		);
+		expect(screen.getByTestId("title").className).toContain("custom-title");
+	});
+});
+
+describe("CardDescription", () => {
+	it("renders children", () => {
+		render(<CardDescription data-testid="desc">A description</CardDescription>);
+		expect(screen.getByTestId("desc")).toHaveTextContent("A description");
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<CardDescription ref={ref}>Desc</CardDescription>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(
+			<CardDescription data-testid="desc" className="custom-desc">
+				Desc
+			</CardDescription>,
+		);
+		expect(screen.getByTestId("desc").className).toContain("custom-desc");
+	});
+});
+
+describe("CardContent", () => {
+	it("renders children", () => {
+		render(<CardContent data-testid="content">Main content</CardContent>);
+		expect(screen.getByTestId("content")).toHaveTextContent("Main content");
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<CardContent ref={ref}>Content</CardContent>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(
+			<CardContent data-testid="content" className="custom-content">
+				Content
+			</CardContent>,
+		);
+		expect(screen.getByTestId("content").className).toContain("custom-content");
+	});
+});
+
+describe("CardFooter", () => {
+	it("renders children", () => {
+		render(<CardFooter data-testid="footer">Footer content</CardFooter>);
+		expect(screen.getByTestId("footer")).toHaveTextContent("Footer content");
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<CardFooter ref={ref}>Footer</CardFooter>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(
+			<CardFooter data-testid="footer" className="custom-footer">
+				Footer
+			</CardFooter>,
+		);
+		expect(screen.getByTestId("footer").className).toContain("custom-footer");
+	});
+});
+
+describe("Card — compound composition", () => {
+	it("renders a complete card with all sub-components", () => {
+		render(
+			<Card data-testid="card">
+				<CardHeader>
+					<CardTitle>Card Title</CardTitle>
+					<CardDescription>Card description</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<p>Card body text</p>
+				</CardContent>
+				<CardFooter>
+					<button type="button">Action</button>
+				</CardFooter>
+			</Card>,
+		);
+
+		expect(screen.getByTestId("card")).toBeInTheDocument();
+		expect(screen.getByText("Card Title")).toBeInTheDocument();
+		expect(screen.getByText("Card description")).toBeInTheDocument();
+		expect(screen.getByText("Card body text")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- Created `.claude/agents/test-writer.md` — a comprehensive agent that writes unit + visual tests for any UI component
- The agent reads component source, understands props/variants/behavior, generates Vitest + RTL unit tests and Playwright visual regression tests, then self-validates by running the suites
- Demonstrated the agent's patterns by writing 21 unit tests for the Card component (all 6 sub-components: Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter)

## Details
The test writer agent includes:
- **Project context** — framework, paths, tools, conventions
- **Step-by-step workflow** — read component, write unit tests, write visual tests, verify, self-validate
- **Required test cases** — default render, variants, sizes, events, disabled/error states, ref forwarding, className merging, accessibility, compound components
- **Code patterns** — real examples from the existing test suite (button, input, badge)
- **Self-validation checklist** — ensures completeness before declaring done
- **Tool permissions** — scoped to `pnpm test:unit`, `pnpm test:visual`, `npx vitest`

## Test plan
- [x] All 49 unit tests pass (`pnpm test:unit`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Lint/format check passes (`pnpm lint`)
- [x] Production build succeeds (`pnpm build`)
- [x] Pre-commit hooks pass (biome, typecheck, commitlint)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)