### PR TITLE
feat(ui): add TestComp component

### DIFF
--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -19,6 +19,7 @@ import {
 	DialogTitle,
 	DialogTrigger,
 	Input,
+	TestComp,
 } from "@/components/ui";
 
 /* ═══════════════════════════════════════════════════
@@ -29,6 +30,8 @@ const BUTTON_VARIANTS = ["primary", "secondary", "outline", "ghost", "destructiv
 const BUTTON_SIZES = ["sm", "md", "lg"] as const;
 const BADGE_VARIANTS = ["default", "success", "warning", "error", "info"] as const;
 const AVATAR_SIZES = ["sm", "md", "lg"] as const;
+const TEST_COMP_VARIANTS = ["default", "highlight", "muted"] as const;
+const TEST_COMP_SIZES = ["sm", "md", "lg"] as const;
 
 /* ═══════════════════════════════════════════════════
    Section heading — numbered specimen labels
@@ -233,6 +236,33 @@ export default function ShowcasePage() {
 							))}
 						</div>
 					</div>
+				</div>
+			</section>
+
+			<hr className="border-border" />
+
+			{/* ── 07 TestComp ──────────────────────────── */}
+			<section>
+				<SectionHeading
+					number="07"
+					title="TestComp"
+					description="3 variants &times; 3 sizes for inline content blocks."
+				/>
+				<div className="space-y-6">
+					{TEST_COMP_VARIANTS.map((variant) => (
+						<div key={variant}>
+							<p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								{variant}
+							</p>
+							<div className="flex flex-wrap items-center gap-3">
+								{TEST_COMP_SIZES.map((size) => (
+									<TestComp key={size} variant={variant} size={size}>
+										{variant} / {size}
+									</TestComp>
+								))}
+							</div>
+						</div>
+					))}
 				</div>
 			</section>
 

--- a/src/components/ui/__tests__/test-comp.test.tsx
+++ b/src/components/ui/__tests__/test-comp.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { TestComp } from "../test-comp";
+
+describe("TestComp", () => {
+	it("renders with default props", () => {
+		render(<TestComp>Hello</TestComp>);
+		expect(screen.getByText("Hello")).toBeInTheDocument();
+	});
+
+	it("renders each variant correctly", () => {
+		const variants = ["default", "highlight", "muted"] as const;
+
+		for (const variant of variants) {
+			const { unmount } = render(<TestComp variant={variant}>{variant}</TestComp>);
+			expect(screen.getByText(variant)).toBeInTheDocument();
+			unmount();
+		}
+	});
+
+	it("renders each size correctly", () => {
+		const sizes = ["sm", "md", "lg"] as const;
+
+		for (const size of sizes) {
+			const { unmount } = render(<TestComp size={size}>{size}</TestComp>);
+			expect(screen.getByText(size)).toBeInTheDocument();
+			unmount();
+		}
+	});
+
+	it("handles click events", async () => {
+		const user = userEvent.setup();
+		const handleClick = vi.fn();
+		render(<TestComp onClick={handleClick}>Clickable</TestComp>);
+
+		await user.click(screen.getByText("Clickable"));
+		expect(handleClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(<TestComp ref={ref}>Ref test</TestComp>);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts custom className", () => {
+		render(<TestComp className="custom-class">Custom</TestComp>);
+		expect(screen.getByText("Custom").className).toContain("custom-class");
+	});
+
+	it("renders children content", () => {
+		render(
+			<TestComp>
+				<span>Nested child</span>
+			</TestComp>,
+		);
+		expect(screen.getByText("Nested child")).toBeInTheDocument();
+	});
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -27,3 +27,5 @@ export {
 } from "./dialog";
 export type { InputProps } from "./input";
 export { Input } from "./input";
+export type { TestCompProps } from "./test-comp";
+export { TestComp, testCompVariants } from "./test-comp";

--- a/src/components/ui/test-comp.tsx
+++ b/src/components/ui/test-comp.tsx
@@ -1,0 +1,37 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+const testCompVariants = cva(
+	"inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-all",
+	{
+		variants: {
+			variant: {
+				default: "border-border bg-secondary/50 text-foreground hover:bg-secondary",
+				highlight: "border-primary/30 bg-primary/10 text-primary hover:bg-primary/20",
+				muted: "border-transparent bg-muted text-muted-foreground hover:text-foreground",
+			},
+			size: {
+				sm: "px-3 py-1 text-xs",
+				md: "px-4 py-2 text-sm",
+				lg: "px-5 py-3 text-base",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "md",
+		},
+	},
+);
+
+type TestCompProps = HTMLAttributes<HTMLDivElement> & VariantProps<typeof testCompVariants>;
+
+const TestComp = forwardRef<HTMLDivElement, TestCompProps>(
+	({ className, variant, size, ...props }, ref) => (
+		<div ref={ref} className={cn(testCompVariants({ variant, size }), className)} {...props} />
+	),
+);
+TestComp.displayName = "TestComp";
+
+export { TestComp, testCompVariants };
+export type { TestCompProps };


### PR DESCRIPTION
## Summary
- Add new `TestComp` UI component with 3 variants (`default`, `highlight`, `muted`) and 3 sizes (`sm`, `md`, `lg`)
- Follow project conventions: `forwardRef`, `cva` variants, `cn()` className merging, barrel export
- Add 7 unit tests and showcase page section (07)

## Changes
| File | Change |
|------|--------|
| `src/components/ui/test-comp.tsx` | New component |
| `src/components/ui/__tests__/test-comp.test.tsx` | 7 unit tests |
| `src/components/ui/index.ts` | Added barrel export |
| `src/app/showcase/page.tsx` | Added section 07 |

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (3 pre-existing infos only)
- [x] `pnpm test:unit` — 35/35 pass (7 new)
- [x] `pnpm test:integration` — 6/6 pass
- [x] `pnpm build` — production build succeeds
- [ ] Visual check: run `pnpm dev` and visit `/showcase` to verify TestComp section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)