### PR TITLE
feat(hooks): add auto-format and verification hooks (#28)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,5 +63,43 @@
 			"mcp__plugin_playwright_playwright__browser_install",
 			"mcp__plugin_playwright_playwright__browser_network_requests"
 		]
+	},
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Write|Edit",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "pnpm biome check --write --unsafe \"$CLAUDE_FILE_PATH\" 2>&1 || true",
+						"timeout": 30,
+						"statusMessage": "Formatting with Biome..."
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "echo '--- TypeCheck ---' && pnpm typecheck 2>&1 | tail -20 && echo '--- Lint ---' && pnpm lint 2>&1 | tail -20",
+						"timeout": 120,
+						"statusMessage": "Running verification (typecheck + lint)..."
+					}
+				]
+			}
+		],
+		"Notification": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "osascript -e 'display notification \"Claude Code task completed\" with title \"design-to-deploy\"'",
+						"timeout": 10
+					}
+				]
+			}
+		]
 	}
 }


### PR DESCRIPTION
## Summary
- Add **PostToolUse** hook to auto-format files with Biome (`biome check --write --unsafe`) after every Write/Edit operation
- Add **Stop** hook to run `pnpm typecheck` and `pnpm lint` verification when Claude completes a task
- Add **Notification** hook for macOS desktop notification on task completion
- Uses Biome (project's adopted formatter/linter) instead of Prettier as referenced in the original issue

Closes #28

## Test plan
- [x] `.claude/settings.json` is valid JSON (validated with Python json parser)
- [x] Hooks configuration follows Claude Code hook schema (validated by Claude Code's built-in schema validator)
- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] Biome lint passes (`pnpm lint`)
- [x] Production build succeeds (`pnpm build`)
- [x] Biome format command works correctly with `$CLAUDE_FILE_PATH` variable
- [x] Pre-commit hooks pass (lefthook: biome, typecheck, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)