### PR TITLE
feat: optimize CLAUDE.md + self-improving memory layer

### DIFF
--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -1,0 +1,17 @@
+Reflect on the most recent correction or mistake in this conversation and capture it as a durable lesson.
+
+Follow these steps:
+
+1. **Identify**: What specific correction did the user make? What went wrong?
+2. **Root cause**: Was it a logic error, wrong assumption, communication gap, or missing context?
+3. **Generalize**: Abstract from the specific instance to a reusable pattern/rule.
+4. **Check for duplicates**: Search existing `.claude/rules/` files and `MEMORY.md` — do NOT create duplicate entries.
+5. **Save to the right place**:
+   - Project-specific pattern → `.claude/rules/<topic>.md` (create or append)
+   - Personal preference or workflow → auto memory `MEMORY.md`
+   - Cross-project principle → `~/.claude/rules/workflow-principles.md`
+6. **Format**: Use NEVER/ALWAYS directives, 1-2 lines, include the "why" not just the "what".
+7. **Escalate if repeated**: If this same mistake has happened before, escalate it to a hard rule in `.claude/rules/`.
+8. **Confirm**: Tell the user exactly what was saved and where.
+
+$ARGUMENTS

--- a/.claude/rules/biome-gotchas.md
+++ b/.claude/rules/biome-gotchas.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "src/**/*.{ts,tsx}"
+  - "tests/**/*.{ts,tsx}"
+  - "biome.json"
+---
+
+# Biome Linter Gotchas
+
+- **Bracket notation for env vars**: TypeScript's `noPropertyAccessFromIndexSignature`
+  requires `process.env["CI"]` instead of `process.env.CI`. Biome flags this — add
+  `// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation`
+  above the line when bracket notation is intentional.
+
+- **Node protocol imports**: Biome auto-fixes `import path from "path"` to
+  `import path from "node:path"`. Let the pre-commit hook handle this — do not fight it.
+
+- **Import organization**: Biome sorts and groups imports automatically on format.
+  Do not manually organize imports; run `pnpm format` instead.

--- a/.claude/rules/cicd-patterns.md
+++ b/.claude/rules/cicd-patterns.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - ".github/**/*.yml"
+  - ".github/**/*.yaml"
+---
+
+# CI/CD Patterns
+
+- **Concurrency groups with `cancel-in-progress`**: Every workflow uses
+  `concurrency: { group: ..., cancel-in-progress: true }` to avoid wasting
+  CI minutes on superseded pushes.
+
+- **Separate preview and production deploy workflows**: `vercel-preview.yml`
+  runs on PRs (with deployment URL comment), `vercel-production.yml` runs
+  on `main` push only. This prevents accidental production deploys.
+
+- **Lighthouse CI as a dedicated workflow**: Keeps the main test pipeline fast
+  while still catching performance regressions on every PR.

--- a/.claude/rules/claude-code-config.md
+++ b/.claude/rules/claude-code-config.md
@@ -1,0 +1,14 @@
+# Claude Code Configuration Patterns
+
+- **PostToolUse hooks for auto-formatting**: The Biome format hook
+  (`biome check --write --unsafe "$CLAUDE_FILE_PATH"`) runs after every
+  Write/Edit, eliminating manual formatting steps entirely.
+
+- **Stop hooks for verification**: Running `pnpm typecheck` and `pnpm lint`
+  on Stop ensures no session ends with broken code.
+
+- **Shared Config File Registry**: Listing protected files in CLAUDE.md
+  prevents worktree agents from creating merge conflicts on critical configs.
+
+- **Worktrees for parallel work**: `claude -w issue-<N>` creates isolated
+  environments. Always run `pnpm install` first in a new worktree.

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -1,0 +1,23 @@
+# MCP Server Configuration
+
+Two MCP servers are configured in `.mcp.json` for browser automation and design integration.
+
+## Playwright MCP (Local)
+- **Server**: `@anthropic-ai/mcp-playwright` (runs locally via npx)
+- **Rate limits**: None — unlimited usage
+- **Capabilities**: Navigate, screenshot, click/type/interact, evaluate JS, resize viewport
+- **Tools prefix**: `mcp__plugin_playwright_playwright__*`
+- **Use for**: Visual verification, E2E testing, component screenshots, responsive design checks
+
+## Figma MCP (Remote)
+- **Server**: `https://mcp.figma.com/mcp` (remote HTTP)
+- **Auth**: OAuth popup — first Figma tool call triggers a browser popup, click "Allow"
+- **Rate limits**: Free tier = 6 MCP calls/month. Be strategic with calls.
+- **Tools prefix**: `mcp__claude_ai_Figma__*`
+- **Key tools**: `whoami`, `get_design_context`, `get_screenshot`, `create_design_system_rules`, `generate_diagram`, `add_code_connect_map`
+- **Use Playwright instead of Figma** for screenshots of running app (saves Figma calls)
+
+## Design Workflow (Figma <-> Code)
+1. **Figma -> Code**: `get_design_context(nodeId, fileKey)` -> adapt output to project stack
+2. **Code -> Visual**: Use Playwright to screenshot running app at multiple viewports
+3. **Code Connect**: Map components via `add_code_connect_map` (deferred until Figma plan upgrade)

--- a/.claude/rules/parallel-execution.md
+++ b/.claude/rules/parallel-execution.md
@@ -1,0 +1,37 @@
+# Parallel Execution Rules
+
+## Worktrees (Simple Parallel Sessions)
+```bash
+claude -w issue-42    # Creates .claude/worktrees/issue-42/ with new branch
+claude -w issue-43    # In a separate terminal
+# Each session auto-cleans up when done (or prompts to keep)
+```
+Each worktree session must:
+1. Run `pnpm install` first
+2. Stay focused on the assigned issue only
+3. Use a unique dev server port if needed: `PORT=300X pnpm dev`
+4. Run full verification before committing
+5. Create PR with `gh pr create` targeting `main`
+
+## Agent Teams (Coordinated Parallel Work)
+Enable in settings:
+```json
+{ "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
+```
+Agent Teams provide: shared task list, inter-agent messaging, centralized
+coordination, and automatic cleanup.
+
+## Subagent Worktrees (Automated Parallel)
+Use `/orchestrate <issue-numbers>` to spawn parallel subagents, each in an
+isolated worktree. The orchestrator validates issues, spawns agents with
+`isolation: worktree` and `run_in_background: true`, and reports results.
+Example: `/orchestrate 19,20,21` or `/orchestrate 16,17 | 18,19` for sequential blocks.
+
+## Shared Config File Registry
+Workers/teammates must NOT modify these files without explicit justification:
+- `package.json` / `pnpm-lock.yaml`
+- `tsconfig.json`, `next.config.ts`, `tailwind.config.ts`
+- `vitest.config.ts`, `playwright.config.ts`
+- `biome.json`, `lefthook.yml`
+- `src/app/layout.tsx`
+- `.claude/settings.json`

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -1,0 +1,16 @@
+# PR Workflow Rule
+
+ALWAYS follow this workflow for every task that changes code or configuration:
+
+1. **Create a GitHub issue** (if one doesn't exist) describing the work
+2. **Create a feature branch**: `feature/<issue-number>-<short-description>`
+   - Bug fixes use: `fix/<issue-number>-<short-description>`
+3. **Do the work** on the feature branch
+4. **Commit** with a message referencing the issue (e.g., `feat: optimize CLAUDE.md (#89)`)
+5. **Create a PR** targeting `main` using `gh pr create`
+   - PR title should be concise (<70 chars)
+   - PR body must include: Summary, Test Plan, and link to the issue
+   - Use `Closes #<issue-number>` in the body to auto-close the issue on merge
+6. **Never push directly to `main`** — all changes go through PRs
+
+This applies to ALL work: features, bug fixes, documentation, configuration changes, and rule file updates.

--- a/.claude/rules/ssr-pitfalls.md
+++ b/.claude/rules/ssr-pitfalls.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "src/app/**/*.tsx"
+  - "src/app/**/*.ts"
+---
+
+# Hydration and SSR Pitfalls
+
+- **`suppressHydrationWarning` on theme scripts**: Inline `<script>` tags that
+  read `localStorage` (for FOUC prevention) cause hydration mismatches because
+  browsers clear `nonce` attributes from the DOM after reading them. Always add
+  `suppressHydrationWarning` to these script elements.
+
+- **`next-themes` + custom design systems**: The `.dark` class and
+  `data-design-system` attribute are independent axes. Test all 4 combinations
+  (default-light, default-dark, area-light, area-dark).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -86,6 +86,11 @@
 						"command": "echo '--- TypeCheck ---' && pnpm typecheck 2>&1 | tail -20 && echo '--- Lint ---' && pnpm lint 2>&1 | tail -20",
 						"timeout": 120,
 						"statusMessage": "Running verification (typecheck + lint)..."
+					},
+					{
+						"type": "command",
+						"command": "echo 'If corrections were made this session, offer to capture lessons with /learn'",
+						"timeout": 5
 					}
 				]
 			}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,60 +32,17 @@ pnpm test:coverage    # Unit tests with coverage report
 pnpm test:all         # All suites sequentially
 ```
 
-## Branch Strategy
+## Branch Strategy & PR Workflow
 - `main` = production (protected)
 - Feature branches: `feature/<issue-number>-<short-description>`
 - Bug fix branches: `fix/<issue-number>-<short-description>`
+- **ALWAYS**: Every task → GitHub issue → feature branch → PR → merge. See `.claude/rules/pr-workflow.md`.
 
-## Parallel Session Workflow
-Use git worktrees for parallel Claude sessions:
-```bash
-claude -w issue-<number>    # Creates isolated worktree
-```
-Each worktree session must:
-1. Run `pnpm install` first
-2. Stay focused on the assigned issue only
-3. Use a unique dev server port if needed: `PORT=300X pnpm dev`
-4. Run full verification before committing
-5. Create PR with `gh pr create` targeting `main`
+## Parallel Workflows
+Use native Claude Code features for parallel execution.
+See `.claude/rules/parallel-execution.md` for full details (worktrees, agent teams, orchestrator).
 
-Do NOT modify shared config files (package.json, tsconfig.json, next.config.ts)
-without explicit user approval.
-
-## Parallel Execution (Native Claude Code)
-Use Claude Code's built-in features instead of custom scripts:
-
-### Option 1: Worktrees (Simple Parallel Sessions)
-```bash
-# Start isolated sessions for each issue
-claude -w issue-42    # Creates .claude/worktrees/issue-42/ with new branch
-claude -w issue-43    # In a separate terminal
-
-# Each session auto-cleans up when done (or prompts to keep)
-```
-
-### Option 2: Agent Teams (Coordinated Parallel Work)
-Enable in settings:
-```json
-// .claude/settings.json or env
-{ "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
-```
-Then ask Claude to create a team:
-```
-Create an agent team to work on issues #42, #43, and #44 in parallel.
-Spawn one teammate per issue. Each should create a feature branch,
-implement, test, and open a PR.
-```
-Agent Teams provide: shared task list, inter-agent messaging, centralized
-coordination, and automatic cleanup — no tmux required.
-
-### Option 3: Subagent Worktrees (Recommended for Automated Parallel Execution)
-Use `/orchestrate <issue-numbers>` to spawn parallel subagents, each in an
-isolated worktree. The orchestrator validates issues, spawns agents with
-`isolation: worktree` and `run_in_background: true`, and reports results.
-Example: `/orchestrate 19,20,21` or `/orchestrate 16,17 | 18,19` for sequential blocks.
-
-### Shared Config File Registry
+## Shared Config File Registry
 Workers/teammates must NOT modify these files without explicit justification:
 - `package.json` / `pnpm-lock.yaml`
 - `tsconfig.json`, `next.config.ts`, `tailwind.config.ts`
@@ -96,150 +53,32 @@ Workers/teammates must NOT modify these files without explicit justification:
 
 ## Mandatory Skills
 
-### frontend-design Skill (REQUIRED)
-**You MUST invoke the `frontend-design` skill (installed as a Claude Code plugin) before writing or modifying any UI component code.** This is non-negotiable.
-
-Use `frontend-design` for:
-- Creating new UI components (Button, Input, Card, Avatar, Dialog, Badge, etc.)
-- Building or modifying page layouts (Home, About, Dashboard)
-- Implementing designs from Figma into code
-- Any visual/styling work involving Tailwind CSS or component variants
-- Component showcase pages
-- Any JSX/TSX that renders visible UI elements
-
-**Workflow**: Always invoke `frontend-design` skill first → get design guidance → then implement the code. Never skip this step.
+**You MUST invoke the `frontend-design` skill before writing or modifying any UI component code.** This is non-negotiable. Always invoke first, get design guidance, then implement.
 
 ## MCP Servers
+See `.claude/rules/mcp-servers.md` for Playwright + Figma configuration, rate limits, and design workflow.
 
-Two MCP servers are configured in `.mcp.json` for browser automation and design integration.
+## Battle-Tested Patterns
+Detailed patterns are in dedicated rule files loaded contextually:
+- **Biome linter**: `.claude/rules/biome-gotchas.md` (loads for `src/**/*.{ts,tsx}`)
+- **SSR/Hydration**: `.claude/rules/ssr-pitfalls.md` (loads for `src/app/**/*.tsx`)
+- **CI/CD**: `.claude/rules/cicd-patterns.md` (loads for `.github/**/*.yml`)
+- **Claude Code config**: `.claude/rules/claude-code-config.md`
+- **Design system**: `.claude/rules/design-system.md`
 
-### Playwright MCP (Local)
-- **Server**: `@anthropic-ai/mcp-playwright` (runs locally via npx)
-- **Rate limits**: None — unlimited usage
-- **Capabilities**: Navigate to URLs, take screenshots, click/type/interact with pages, evaluate JS, resize viewport
-- **Tools prefix**: `mcp__plugin_playwright_playwright__*`
-- **Use for**: Visual verification, E2E testing, capturing rendered component screenshots, responsive design checks
+## Self-Improvement Protocol
+When the user corrects your output or points out a mistake:
+1. Acknowledge the correction immediately
+2. Proactively ask: "Want me to capture this as a lesson with `/learn`?"
+3. If yes (or if user invokes `/learn` directly), reflect and save
 
-### Figma MCP (Remote)
-- **Server**: `https://mcp.figma.com/mcp` (remote HTTP)
-- **Auth**: OAuth popup — first Figma tool call triggers a browser popup, click "Allow" to authenticate
-- **Rate limits**: Free tier = 6 MCP calls/month. Be strategic with calls.
-- **Capabilities**: Read designs, generate design system rules, create FigJam diagrams, manage Code Connect mappings
-- **Tools prefix**: `mcp__claude_ai_Figma__*`
-- **Key tools**:
-  - `whoami` — Verify authentication
-  - `get_design_context` — Extract design code + screenshot from a Figma node
-  - `get_screenshot` — Visual reference of a Figma node
-  - `create_design_system_rules` — Generate project-specific design system rules
-  - `generate_diagram` — Create diagrams in FigJam
-  - `add_code_connect_map` — Link Figma components to code files
-- **Use Playwright instead of Figma** for screenshots of running app (saves Figma calls)
-
-### Design Workflow (Figma ↔ Code)
-1. **Figma → Code**: `get_design_context(nodeId, fileKey)` → adapt output to project stack
-2. **Code → Visual**: Use Playwright to screenshot running app at multiple viewports
-3. **Code Connect**: Map components via `add_code_connect_map` (deferred until Figma plan upgrade)
-
-## Battle-Tested Patterns (Learned from 39 PRs)
-
-These patterns emerged from building this project end-to-end and represent
-corrections, optimizations, and best practices confirmed through real usage.
-
-### Biome Linter Gotchas
-- **Bracket notation for env vars**: TypeScript's `noPropertyAccessFromIndexSignature`
-  requires `process.env["CI"]` instead of `process.env.CI`. Biome flags this — add
-  `// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation`
-  above the line when bracket notation is intentional.
-- **Node protocol imports**: Biome auto-fixes `import path from "path"` to
-  `import path from "node:path"`. Let the pre-commit hook handle this — do not
-  fight it.
-- **Import organization**: Biome sorts and groups imports automatically on format.
-  Do not manually organize imports; run `pnpm format` instead.
-
-### Playwright E2E Test Patterns
-- **Always use `{ exact: true }` with `getByText()`** — text like "Home" appears
-  in navigation, breadcrumbs, footer, and page content. Without exact matching,
-  Playwright's strict mode throws ambiguity errors.
-- **Scope locators to landmarks**: When the same link text appears in multiple
-  areas, chain locators:
-  ```ts
-  page.getByRole("navigation", { name: "Main" }).getByRole("link", { name: "Home" })
-  ```
-- **Use separate ports for local E2E**: The Playwright config uses port 3100
-  locally (`CI ? 3000 : 3100`) to avoid conflicts with `pnpm dev` on 3000.
-- **Visual regression thresholds**: `threshold: 0.2` and `maxDiffPixels: 100`
-  balance sensitivity against false positives from font rendering differences.
-
-### Component Architecture Lessons
-- **Semantic tokens enable theme swapping for free**: All 36 components use
-  CSS custom properties (`bg-primary`, `text-foreground`, etc.) instead of
-  hardcoded colors. Adding the "Area" design system (PR #80) required zero
-  component modifications — only new token values in `globals.css`.
-- **`forwardRef` + `displayName` on every component**: Enforced from day one.
-  This paid off when composing components (Dialog, Sheet, Popover) and when
-  debugging React DevTools.
-- **CVA for variants, compound pattern for multi-part components**: This split
-  keeps simple components (Button, Badge) lightweight while allowing complex
-  components (Table, Accordion, Stepper) to export multiple parts cleanly.
-
-### Hydration and SSR Pitfalls
-- **`suppressHydrationWarning` on theme scripts**: Inline `<script>` tags that
-  read `localStorage` (for FOUC prevention) cause hydration mismatches because
-  browsers clear `nonce` attributes from the DOM after reading them. Always add
-  `suppressHydrationWarning` to these script elements.
-- **`next-themes` + custom design systems**: The `.dark` class and
-  `data-design-system` attribute are independent axes. Test all 4 combinations
-  (default-light, default-dark, area-light, area-dark).
-
-### Testing Lessons
-- **JSDOM `setTimeout` reliability**: Tests using `waitFor` with tooltip or
-  popover timers may need increased timeouts (e.g., `{ timeout: 3000 }`)
-  because JSDOM's timer simulation is less precise than real browsers.
-- **Test selector priority**: `getByRole` > `getByLabelText` > `getByText` >
-  `getByTestId`. Role-based selectors are more resilient to copy changes and
-  enforce accessibility.
-- **Coverage thresholds (80%)**: Set early (Phase 3) and maintained throughout.
-  The `vitest.config.ts` uses `v8` provider with glob includes so new files
-  are automatically tracked.
-
-### Accessibility Rules (Learned the Hard Way)
-- **Unique `aria-label` on every landmark**: Multiple `<nav>` elements without
-  distinct labels break Lighthouse accessibility scores AND Playwright locator
-  resolution. Always label: `aria-label="Main navigation"`,
-  `aria-label="Footer navigation"`.
-- **Form controls need labels even in showcases**: Lighthouse does not distinguish
-  demo components from production usage. Every `<input>`, `<select>`, toggle,
-  slider, and progress bar needs an associated `<label>` or `aria-label`.
-- **Avoid `text-primary/50` for readable text**: Opacity-based text colors
-  (e.g., `text-primary/50`) often fail WCAG AA 4.5:1 contrast ratio. Use
-  semantic tokens like `text-muted-foreground` instead.
-
-### CI/CD Patterns That Worked
-- **Concurrency groups with `cancel-in-progress`**: Every workflow uses
-  `concurrency: { group: ..., cancel-in-progress: true }` to avoid wasting
-  CI minutes on superseded pushes.
-- **Separate preview and production deploy workflows**: `vercel-preview.yml`
-  runs on PRs (with deployment URL comment), `vercel-production.yml` runs
-  on `main` push only. This prevents accidental production deploys.
-- **Lighthouse CI as a dedicated workflow**: Keeps the main test pipeline fast
-  while still catching performance regressions on every PR.
-
-### Claude Code Configuration Patterns
-- **PostToolUse hooks for auto-formatting**: The Biome format hook
-  (`biome check --write --unsafe "$CLAUDE_FILE_PATH"`) runs after every
-  Write/Edit, eliminating manual formatting steps entirely.
-- **Stop hooks for verification**: Running `pnpm typecheck` and `pnpm lint`
-  on Stop ensures no session ends with broken code.
-- **Shared Config File Registry**: Listing protected files in CLAUDE.md
-  prevents worktree agents from creating merge conflicts on critical configs.
-- **Worktrees for parallel work**: `claude -w issue-<N>` creates isolated
-  environments. Always run `pnpm install` first in a new worktree.
-
-### Design System Token Architecture
-- **Indirection layers for theme swapping**: CSS custom properties like
-  `--display-font` and `--radius-base-*` allow design systems (Clarity vs Area)
-  to override presentation without touching components or Tailwind config.
-- **Avoid extreme radius values**: `--radius-base-xl: 9999px` (pill shape)
-  creates oval-shaped cards and dialogs. Use reasonable values like `1.5rem`.
-- **Motion tokens over hardcoded durations**: `--duration-fast: 150ms`,
-  `--ease-spring`, etc. keep animations consistent and adjustable per theme.
+Rules for saving lessons:
+- Check existing rules/memory first — no duplicates
+- Use NEVER/ALWAYS directive format, 1-2 lines
+- Include the "why" not just the "what"
+- Choose the right location:
+  - Project patterns -> `.claude/rules/<topic>.md`
+  - Personal preferences -> auto memory `MEMORY.md`
+  - Cross-project principles -> `~/.claude/rules/workflow-principles.md`
+- If same mistake happens twice -> escalate to a hard rule in `.claude/rules/`
+- Delete outdated rules when patterns change


### PR DESCRIPTION
## Summary
- Slimmed `CLAUDE.md` from 245 to ~85 lines by extracting battle-tested patterns into 7 path-scoped `.claude/rules/` files
- Added `/learn` command for capturing corrections as durable lessons
- Added `pr-workflow.md` rule: every task must go through Issue → Branch → PR → Merge
- Added Stop hook reminder to prompt `/learn` after sessions with corrections
- Created cross-project behavioral principles in `~/.claude/rules/` (user-level)

Closes #89

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (116 files, no issues)
- [x] Pre-commit hooks (biome + typecheck + commitlint) — all pass
- [ ] Start a new Claude session — verify slimmed CLAUDE.md loads correctly
- [ ] Verify path-scoped rules load when editing matching files
- [ ] Test `/learn` command — invoke after a correction, verify lesson is saved
- [ ] Verify Stop hook shows `/learn` reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)