### PR TITLE
feat: add task planning & agent orchestration principles

### DIFF
--- a/.claude/rules/task-planning.md
+++ b/.claude/rules/task-planning.md
@@ -1,0 +1,50 @@
+# Task Planning & Agent Orchestration
+
+Based on Boris Cherny's workflow (Claude Code creator).
+
+## Plan First — Always
+- ALWAYS start in Plan mode for non-trivial tasks. Planning is cheap; rework is expensive.
+- Iterate on the plan with the user until both sides are satisfied BEFORE writing code.
+- After plan approval, switch to auto-accept edits mode — Claude can usually one-shot it.
+- Use Plan mode for: PRs, bug investigation, codebase exploration, performance work, multi-file changes.
+- Skip Plan mode ONLY for: single-line fixes, typos, obvious bugs, very specific instructions.
+
+## Agent Execution Sequence
+For a typical feature task, follow this order:
+
+1. **Explore** — Use the Explore agent to understand the codebase area before planning.
+2. **Plan** — Use Plan mode or the Plan agent to design the approach. Get user sign-off.
+3. **Implement** — Write the code. Use auto-accept mode after plan approval.
+4. **Simplify** — Run `code-simplifier` agent to reduce complexity as a cleanup pass.
+5. **Verify** — Run `/verify` (typecheck + lint + tests). Use Playwright for visual checks.
+6. **Review** — Run `code-reviewer` agent to catch issues before creating the PR.
+7. **Ship** — Run `/pr-ready` to create the branch and PR.
+
+Not every step is needed for every task — scale to complexity.
+
+## Subagent Selection Rules
+- **Explore agent**: Codebase research, finding files/patterns, understanding architecture.
+- **Plan agent**: Architectural design, identifying files to create/modify, trade-off analysis.
+- **code-simplifier**: Post-implementation cleanup. ALWAYS run after complex changes.
+- **code-reviewer**: Pre-PR validation. Catches bugs, security issues, style violations.
+- **test-writer**: When test coverage is needed for new/modified components.
+- **design-implementer**: When implementing from Figma designs.
+- Use subagents for **isolated results or side effects** — they protect main context from bloat.
+- NEVER duplicate work: if you delegate research to a subagent, don't also search yourself.
+- Specialization > generalization: modular roles with constraints are more reliable than one big agent.
+
+## Verification Loops — Non-Negotiable
+- ALWAYS give Claude a way to verify its work. This 2-3x the quality of final results.
+- Match verification to domain:
+  - **TypeScript/Lint**: `pnpm typecheck && pnpm lint`
+  - **Unit tests**: `pnpm test:unit`
+  - **Frontend/Visual**: Playwright MCP screenshots at multiple viewports
+  - **E2E**: `pnpm test:e2e`
+- Run the full verification pipeline before declaring done.
+- Hooks handle automatic quality gates — don't fight them, lean into them.
+
+## Async & Parallel Mindset
+- AI coding is asynchronous, not synchronous. Launch parallel work where possible.
+- Use `run_in_background: true` for independent subagents; continue other work while they run.
+- Batch reviews: review multiple outputs together rather than constant checking.
+- Use system notifications to know when Claude needs input — don't poll.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ pnpm test:all         # All suites sequentially
 - Bug fix branches: `fix/<issue-number>-<short-description>`
 - **ALWAYS**: Every task → GitHub issue → feature branch → PR → merge. See `.claude/rules/pr-workflow.md`.
 
+## Task Planning & Execution
+ALWAYS plan before building. See `.claude/rules/task-planning.md` for the full sequence:
+Explore → Plan → Implement → Simplify → Verify → Review → Ship.
+
 ## Parallel Workflows
 Use native Claude Code features for parallel execution.
 See `.claude/rules/parallel-execution.md` for full details (worktrees, agent teams, orchestrator).


### PR DESCRIPTION
## Summary
- Added `.claude/rules/task-planning.md` with Boris Cherny's workflow methodology
- Updated `CLAUDE.md` to reference the new task planning rule

Key principles captured:
- **Plan First**: ALWAYS start in Plan mode for non-trivial tasks
- **Agent Execution Sequence**: Explore → Plan → Implement → Simplify → Verify → Review → Ship
- **Subagent Selection**: When to use Explore, Plan, code-simplifier, code-reviewer, etc.
- **Verification Loops**: Non-negotiable quality gates matching domain to verification method
- **Async Parallel Mindset**: Background subagents, batch reviews, notifications

Closes #91

## Test plan
- [x] `pnpm typecheck` — passes
- [x] Pre-commit hooks (typecheck + commitlint) — pass
- [ ] Start new session — verify task-planning rule loads and influences behavior
- [ ] Verify CLAUDE.md references the new rule file

🤖 Generated with [Claude Code](https://claude.com/claude-code)