### PR TITLE
feat: integrate Framer Motion animation library (#95)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -49,6 +49,14 @@ For each file, check:
 - [ ] No inline function definitions in JSX that cause unnecessary re-renders
 - [ ] Avoid importing entire libraries when only specific exports are needed
 
+### Animation (Framer Motion)
+- [ ] `motion.*` components only used in `"use client"` files
+- [ ] `useReducedMotion()` checked (or using wrapper components that handle it)
+- [ ] Spring presets imported from `@/lib/motion` (not hardcoded values)
+- [ ] No layout-thrashing animations (animating width/height — use transform instead)
+- [ ] `AnimatePresence` used with `key` prop for exit animations
+- [ ] `aria-hidden="true"` on purely decorative animated elements
+
 ### Security
 - [ ] No `dangerouslySetInnerHTML` without sanitization
 - [ ] No secrets or API keys in client code

--- a/.claude/agents/design-implementer.md
+++ b/.claude/agents/design-implementer.md
@@ -203,6 +203,16 @@ Light `:root` / Dark `.dark` tokens:
 `--accent`, `--accent-foreground`, `--destructive`, `--destructive-foreground`,
 `--border`, `--input`, `--ring`
 
+## Animation Integration
+When implementing designs with animations:
+
+1. **Decide CSS vs Framer Motion**: Use CSS for hover/focus transitions, dialog open/close, infinite loops. Use Framer Motion for viewport reveals, stagger sequences, spring physics, exit animations.
+2. **Implementation pattern**: Import presets from `@/lib/motion`, wrap elements with `MotionReveal`/`MotionStagger`/`MotionItem` from `@/components/motion`
+3. **SSR boundary**: All `motion.*` components MUST be in `"use client"` files. The wrapper components handle this.
+4. **Spring presets**: Use `springs.snappy` (micro-interactions), `springs.default` (general), `springs.gentle` (reveals), `springs.bouncy` (emphasis)
+5. **Interaction presets**: Use `hoverLift`, `hoverScale`, `tapShrink` from `@/lib/motion` with spread syntax: `<motion.div {...hoverLift}>`
+6. **Accessibility**: Wrapper components handle `useReducedMotion()` automatically. When using `motion.*` directly, always check and skip animation.
+
 ## Key Rules
 1. Never hardcode color values -- always use design tokens
 2. Never skip `forwardRef` or `displayName`

--- a/.claude/agents/feature-orchestrator.md
+++ b/.claude/agents/feature-orchestrator.md
@@ -82,6 +82,8 @@ You can delegate work to these specialized agents defined in `.claude/agents/`:
 - Always use `forwardRef`, set `displayName`, accept `className`
 - Export types alongside components
 - Add new components to barrel export in `src/components/ui/index.ts`
+- Use motion utilities from `@/lib/motion` and `@/components/motion` for animations
+- Import spring/variant presets — never hardcode animation values
 
 **For non-UI work** — implement directly:
 - API routes, utilities, configuration, scripts
@@ -128,6 +130,7 @@ Utilities:   src/lib/<name>.ts
 - Security: no exposed secrets, input validation on API routes
 - Code quality: conventions followed, no dead code, tests exist
 - Tailwind: semantic tokens only, mobile-first responsive, no conflicting classes
+- Animation: `useReducedMotion()` respected, spring presets from `@/lib/motion`, no layout-thrashing
 
 **Fix any critical issues** identified during review before proceeding.
 

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -154,9 +154,46 @@ Before declaring tests complete, verify:
 - [ ] Visual tests cover both light and dark themes
 - [ ] All tests pass when run
 
+## Testing Animated Components
+When testing components that use Framer Motion (`motion/react`):
+
+1. **Mock `motion/react`** in the test file to replace `motion.*` with plain HTML:
+```tsx
+import { createElement, forwardRef } from "react";
+
+const motionPropKeys = new Set([
+  "initial", "animate", "exit", "variants", "transition",
+  "whileHover", "whileTap", "whileFocus", "whileDrag", "whileInView",
+  "viewport", "layout", "layoutId", "onAnimationStart", "onAnimationComplete",
+]);
+
+vi.mock("motion/react", () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+        const htmlProps: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(props)) {
+          if (!motionPropKeys.has(key)) htmlProps[key] = value;
+        }
+        return createElement(prop, { ...htmlProps, ref });
+      });
+      Comp.displayName = `motion.${prop}`;
+      return Comp;
+    },
+  }),
+  useReducedMotion: () => false,
+  AnimatePresence: ({ children }: { children: unknown }) => children,
+}));
+```
+
+2. **What to test**: Rendering, props, refs, events, className merging
+3. **What NOT to test**: Animation values (opacity, transform, spring physics)
+4. See `src/components/motion/__tests__/motion.test.tsx` for the reference implementation
+
 ## Reference files
 Use these existing test files as reference for patterns and style:
 - `src/components/ui/__tests__/button.test.tsx` — comprehensive unit test example
 - `src/components/ui/__tests__/input.test.tsx` — form element with label/error states
 - `src/components/ui/__tests__/badge.test.tsx` — simple variant testing
+- `src/components/motion/__tests__/motion.test.tsx` — animated component testing
 - `tests/visual/components.spec.ts` — visual regression test patterns

--- a/.claude/agents/verify-app.md
+++ b/.claude/agents/verify-app.md
@@ -60,7 +60,10 @@ If the changes involve UI:
 3. Take screenshots at key viewpoints (1280px, 768px, 375px)
 4. Check browser console for errors or warnings
 5. Verify interactive elements work (click, type, hover)
-6. Close browser when done
+6. Verify animations play correctly on scroll (viewport reveals, staggers)
+7. Emulate `prefers-reduced-motion: reduce` and confirm animations are suppressed
+8. Confirm smooth performance at 375px mobile viewport
+9. Close browser when done
 
 ### 5. Edge Cases
 - Test with invalid inputs where applicable

--- a/.claude/rules/animation-patterns.md
+++ b/.claude/rules/animation-patterns.md
@@ -1,0 +1,108 @@
+# Animation Patterns — CSS vs Framer Motion
+
+Scoped to: `src/components/motion/**`, `src/components/landing/**`, `src/app/**/page.tsx`
+
+## When to Use CSS vs Framer Motion
+
+| Use CSS | Use Framer Motion |
+|---------|-------------------|
+| Hover/focus transitions | Viewport-triggered reveals |
+| Dialog open/close (Radix) | Staggered entrance sequences |
+| Infinite decorative loops (orbs, pulses) | Spring physics (natural bounce/ease) |
+| Theme toggle animation | Exit animations (AnimatePresence) |
+| Simple opacity/transform on `:hover` | Layout animations (shared layout) |
+| Skeleton pulse animations | Scroll-linked progress |
+| | Interactive feedback (hover lift, tap shrink) |
+| | SVG path drawing |
+
+## SSR Rules
+- `motion.*` components MUST be in `"use client"` files or imported from client components
+- Import from `motion/react` (NOT `framer-motion` — renamed at v11)
+- The wrapper components in `src/components/motion/` handle the client boundary
+
+## Spring Preset Reference
+
+| Preset | Stiffness | Damping | Use Case |
+|--------|-----------|---------|----------|
+| `snappy` | 400 | 30 | Buttons, toggles, micro-interactions |
+| `default` | 200 | 24 | General purpose, balanced feel |
+| `gentle` | 80 | 14 | Viewport reveals, page entrances |
+| `bouncy` | 300 | 12 | Hero elements, playful emphasis |
+
+All presets defined in `src/lib/tokens.ts` and re-exported from `src/lib/motion.ts`.
+
+## Pattern Examples
+
+### Viewport Reveal
+```tsx
+import { MotionReveal } from "@/components/motion";
+
+<MotionReveal direction="up" spring="gentle">
+  <h2>Section Title</h2>
+</MotionReveal>
+```
+
+### Staggered Children
+```tsx
+import { MotionStagger, MotionItem } from "@/components/motion";
+
+<MotionStagger stagger={0.1} className="grid grid-cols-3 gap-4">
+  {items.map((item) => (
+    <MotionItem key={item.id}>
+      <Card>{item.content}</Card>
+    </MotionItem>
+  ))}
+</MotionStagger>
+```
+
+### Interactive Feedback (spread pattern)
+```tsx
+import { motion } from "motion/react";
+import { hoverLift } from "@/lib/motion";
+
+<motion.div {...hoverLift}>
+  <Card>Hover me</Card>
+</motion.div>
+```
+
+## Accessibility — Non-Negotiable
+- ALWAYS call `useReducedMotion()` in components that animate
+- The wrapper components (`MotionReveal`, `MotionStagger`, `MotionItem`) handle this automatically
+- When using `motion.*` directly, check `useReducedMotion()` and set `transition: { duration: 0 }` if true
+- Add `aria-hidden="true"` on purely decorative animated elements (particles, orbs)
+
+## Testing Animated Components
+Mock `motion/react` in Vitest to replace `motion.*` with plain HTML elements:
+```tsx
+vi.mock("motion/react", () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      const Component = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+        const htmlProps: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(props)) {
+          if (!key.startsWith("while") && !key.startsWith("animate") &&
+              !["initial", "exit", "variants", "transition", "viewport",
+               "whileInView", "layout", "layoutId"].includes(key)) {
+            htmlProps[key] = value;
+          }
+        }
+        return createElement(prop, { ...htmlProps, ref });
+      });
+      Component.displayName = `motion.${prop}`;
+      return Component;
+    },
+  }),
+  useReducedMotion: () => false,
+  AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+```
+
+Unit tests should verify: rendering, props, refs, events, className merging.
+Do NOT test actual animation values — that's Framer Motion's responsibility.
+
+## Advanced Patterns (Reference)
+These are available in the `motion` package but not wrapped in our utilities:
+- **Layout animations**: `layout` prop on `motion.*` for smooth layout shifts
+- **Exit animations**: `AnimatePresence` + `exit` prop for unmount animations
+- **Scroll-linked progress**: `useScroll()` + `useTransform()` for parallax/progress bars
+- **SVG path drawing**: `pathDraw` variant from `@/lib/motion` with `motion.path`

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -59,9 +59,21 @@ Part.displayName = "Part";
 - Use `font-display` for headings and hero text
 
 ### Motion
+
+**CSS Tokens** (for simple transitions):
 - Durations: `--duration-instant` (50ms), `--duration-fast` (150ms), `--duration-normal` (250ms), `--duration-slow` (400ms), `--duration-slower` (600ms)
 - Easing: `--ease-default`, `--ease-spring`, `--ease-out`
-- Use CSS transitions, not JS animation libraries
+- Use CSS transitions for: hover, focus, theme toggle, dialog open/close, infinite loops
+
+**Framer Motion** (for complex animations):
+- Package: `motion` — import from `motion/react`
+- Spring presets: `snappy` (400/30), `default` (200/24), `gentle` (80/14), `bouncy` (300/12)
+- Wrapper components: `MotionReveal`, `MotionStagger`, `MotionItem` in `src/components/motion/`
+- Interaction presets: `hoverLift`, `hoverScale`, `tapShrink` in `src/lib/motion.ts`
+- Use for: viewport reveals, stagger sequences, spring physics, exit animations, SVG path drawing
+- All motion components MUST be in `"use client"` files
+- ALWAYS respect `useReducedMotion()` — wrapper components handle this automatically
+- See `.claude/rules/animation-patterns.md` for full decision matrix and examples
 
 ### Spacing & Radius
 - Spacing: Tailwind default scale (0–20)

--- a/.claude/skills/frontend-stack/SKILL.md
+++ b/.claude/skills/frontend-stack/SKILL.md
@@ -114,6 +114,15 @@ Complex interactive components (Avatar, Dialog) use Radix UI primitives:
 - `@radix-ui/react-dialog` for Dialog
 - `@radix-ui/react-slot` for polymorphic components
 
+### Framer Motion (Animation)
+- **Package**: `motion` (v12+) — import from `motion/react` (NOT `framer-motion`)
+- **SSR**: All `motion.*` components MUST be in `"use client"` files
+- **Presets**: Spring configs, variant presets, interaction helpers in `src/lib/motion.ts`
+- **Wrapper components**: `MotionReveal`, `MotionStagger`, `MotionItem` in `src/components/motion/`
+- **Accessibility**: ALWAYS call `useReducedMotion()` — wrapper components handle this automatically
+- **Decision guide**: Use CSS for hover/focus/infinite loops; use Framer Motion for viewport reveals, stagger, springs, exit animations
+- See `.claude/rules/animation-patterns.md` for complete patterns
+
 ## Existing Components
 | Component | Type | Variants |
 |-----------|------|----------|

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -91,6 +91,34 @@ Playwright runs in strict mode by default — if a locator matches multiple elem
 - Screenshot config: threshold 0.2, maxDiffPixels 100
 - Update baselines: `pnpm test:visual -- --update-snapshots`
 
+## Testing Animated Components
+When testing components that use Framer Motion (`motion/react`):
+
+1. **Mock `motion/react`** to replace `motion.*` with plain HTML elements:
+```tsx
+vi.mock("motion/react", () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      const Component = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+        const htmlProps: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(props)) {
+          if (!motionPropKeys.has(key)) htmlProps[key] = value;
+        }
+        return createElement(prop, { ...htmlProps, ref });
+      });
+      Component.displayName = `motion.${prop}`;
+      return Component;
+    },
+  }),
+  useReducedMotion: () => false,
+  AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+```
+
+2. **Test behavior, not animation values**: Verify rendering, props, refs, events, className merging
+3. **Do NOT test**: Animation values (opacity, transform, spring physics) — that's Framer Motion's responsibility
+4. **Visual regression**: Disable animations in Playwright with `animation-duration: 0s !important`
+
 ## Running Tests
 - Unit: `pnpm test:unit`
 - Integration: `pnpm test:integration`

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@vercel/speed-insights": "^1.3.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"motion": "^12.34.3",
 		"next": "16.1.6",
 		"next-themes": "^0.4.6",
 		"pino": "^10.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      motion:
+        specifier: ^12.34.3
+        version: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2588,6 +2591,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.34.3:
+    resolution: {integrity: sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -3181,6 +3198,26 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@12.34.3:
+    resolution: {integrity: sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==}
+
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+
+  motion@12.34.3:
+    resolution: {integrity: sha512-xZIkBGO7v/Uvm+EyaqYd+9IpXu0sZqLywVlGdCFrrMiaO9JI4Kx51mO9KlHSWwll+gZUVY5OJsWgYI5FywJ/tw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -6681,6 +6718,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.34.3
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fresh@0.5.2: {}
 
   fs.realpath@1.0.0: {}
@@ -7252,6 +7298,20 @@ snapshots:
       minimist: 1.2.8
 
   module-details-from-path@1.0.4: {}
+
+  motion-dom@12.34.3:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
+
+  motion@12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   mrmime@2.0.1: {}
 

--- a/src/components/landing/cta-section.tsx
+++ b/src/components/landing/cta-section.tsx
@@ -1,54 +1,59 @@
+"use client";
+
+import { MotionReveal } from "@/components/motion";
 import { Button } from "@/components/ui/button";
 
 export function CtaSection() {
 	return (
 		<section className="py-24 sm:py-32">
 			<div className="mx-auto max-w-6xl px-6 sm:px-8">
-				<div className="relative overflow-hidden rounded-2xl bg-primary px-8 py-16 sm:px-16 sm:py-20">
-					{/* Background accent shapes */}
-					<div
-						className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-accent/20 blur-3xl"
-						aria-hidden="true"
-					/>
-					<div
-						className="pointer-events-none absolute -bottom-10 -left-10 h-48 w-48 rounded-full bg-white/10 blur-2xl"
-						aria-hidden="true"
-					/>
+				<MotionReveal direction="up" spring="default">
+					<div className="relative overflow-hidden rounded-2xl bg-primary px-8 py-16 sm:px-16 sm:py-20">
+						{/* Background accent shapes */}
+						<div
+							className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-accent/20 blur-3xl"
+							aria-hidden="true"
+						/>
+						<div
+							className="pointer-events-none absolute -bottom-10 -left-10 h-48 w-48 rounded-full bg-white/10 blur-2xl"
+							aria-hidden="true"
+						/>
 
-					<div className="relative max-w-xl">
-						<h2 className="font-display text-3xl font-bold tracking-tight text-primary-foreground sm:text-4xl">
-							Start building with
-							<br />
-							Clarity today.
-						</h2>
-						<p className="mt-4 text-lg text-primary-foreground/80">
-							Install the library, import a component, and ship. No configuration ceremony. No
-							learning curve. Just good components.
-						</p>
+						<div className="relative max-w-xl">
+							<h2 className="font-display text-3xl font-bold tracking-tight text-primary-foreground sm:text-4xl">
+								Start building with
+								<br />
+								Clarity today.
+							</h2>
+							<p className="mt-4 text-lg text-primary-foreground/80">
+								Install the library, import a component, and ship. No configuration ceremony. No
+								learning curve. Just good components.
+							</p>
 
-						{/* Code snippet */}
-						<div className="mt-8 rounded-lg bg-black/20 px-4 py-3 font-mono text-sm text-primary-foreground/90 backdrop-blur-sm">
-							<span className="select-none text-primary-foreground/50">$ </span>
-							pnpm add @clarity/ui
-						</div>
+							{/* Code snippet */}
+							<div className="mt-8 rounded-lg bg-black/20 px-4 py-3 font-mono text-sm text-primary-foreground/90 backdrop-blur-sm">
+								<span className="select-none text-primary-foreground/50">$ </span>
+								pnpm add @clarity/ui
+							</div>
 
-						<div className="mt-8 flex flex-wrap gap-4">
-							<Button
-								size="lg"
-								className="bg-primary-foreground text-primary hover:bg-primary-foreground/90"
-							>
-								Get Started
-							</Button>
-							<Button
-								variant="outline"
-								size="lg"
-								className="border-primary-foreground/30 text-primary-foreground hover:bg-primary-foreground/10"
-							>
-								Read the Docs
-							</Button>
+							<div className="mt-8 flex flex-wrap gap-4">
+								<Button
+									size="lg"
+									className="bg-primary-foreground text-primary hover:bg-primary-foreground/90"
+								>
+									Get Started
+								</Button>
+								<Button
+									variant="outline"
+									size="lg"
+									className="border-primary-foreground/30 text-primary-foreground hover:bg-primary-foreground/10"
+								>
+									Read the Docs
+								</Button>
+							</div>
 						</div>
 					</div>
-				</div>
+				</MotionReveal>
 			</div>
 		</section>
 	);

--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -1,4 +1,9 @@
+"use client";
+
+import { motion } from "motion/react";
+import { MotionItem, MotionReveal, MotionStagger } from "@/components/motion";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { hoverLift } from "@/lib/motion";
 
 const features = [
 	{
@@ -106,7 +111,7 @@ export function Features() {
 
 			<div className="mx-auto max-w-6xl px-6 sm:px-8">
 				{/* Section header */}
-				<div className="mb-16 max-w-2xl">
+				<MotionReveal direction="up" spring="gentle" className="mb-16 max-w-2xl">
 					<p className="mb-3 font-mono text-sm font-medium uppercase tracking-wider text-primary">
 						Features
 					</p>
@@ -119,22 +124,26 @@ export function Features() {
 						Built for real products, not demos. Each component is battle-tested, fully typed, and
 						ready for production.
 					</p>
-				</div>
+				</MotionReveal>
 
 				{/* Feature cards */}
-				<div className="grid gap-6 sm:grid-cols-2">
+				<MotionStagger stagger={0.1} className="grid gap-6 sm:grid-cols-2">
 					{features.map((feature) => (
-						<Card key={feature.title} className="group transition-shadow hover:shadow-md">
-							<CardHeader>
-								<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-									{feature.icon}
-								</div>
-								<CardTitle>{feature.title}</CardTitle>
-								<CardDescription>{feature.description}</CardDescription>
-							</CardHeader>
-						</Card>
+						<MotionItem key={feature.title}>
+							<motion.div {...hoverLift}>
+								<Card className="group transition-shadow hover:shadow-md">
+									<CardHeader>
+										<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+											{feature.icon}
+										</div>
+										<CardTitle>{feature.title}</CardTitle>
+										<CardDescription>{feature.description}</CardDescription>
+									</CardHeader>
+								</Card>
+							</motion.div>
+						</MotionItem>
 					))}
-				</div>
+				</MotionStagger>
 			</div>
 		</section>
 	);

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,10 +1,22 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { createStaggerContainer, fadeInUp, reducedMotionTransition, springs } from "@/lib/motion";
 
 export function Hero() {
+	const shouldReduce = useReducedMotion();
+
+	const containerVariants = shouldReduce
+		? { hidden: {}, visible: {} }
+		: createStaggerContainer(0.12, 0.1);
+
+	const itemTransition = shouldReduce ? reducedMotionTransition : springs.gentle;
+
 	return (
 		<section className="relative min-h-[90vh] flex items-center overflow-hidden">
-			{/* Floating orb — decorative gradient sphere */}
+			{/* Floating orb — decorative gradient sphere (CSS animation, kept) */}
 			<div
 				className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[500px] w-[500px] animate-landing-orb rounded-full opacity-30 blur-3xl dark:opacity-20"
 				style={{
@@ -14,57 +26,67 @@ export function Hero() {
 				aria-hidden="true"
 			/>
 
-			{/* Pulse ring accent */}
+			{/* Pulse ring accent (CSS animation, kept) */}
 			<div
 				className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[300px] w-[300px] -translate-x-1/2 -translate-y-1/2 animate-landing-pulse rounded-full border border-primary/20"
 				aria-hidden="true"
 			/>
 
 			<div className="mx-auto w-full max-w-6xl px-6 py-24 sm:px-8">
-				<div className="max-w-3xl">
+				<motion.div
+					className="max-w-3xl"
+					initial="hidden"
+					whileInView="visible"
+					viewport={{ once: true, amount: 0.2 }}
+					variants={containerVariants}
+				>
 					{/* Eyebrow */}
-					<div className="animate-landing-reveal" style={{ animationDelay: "0ms" }}>
+					<motion.div variants={fadeInUp} transition={itemTransition}>
 						<Badge variant="info" className="mb-6">
 							v1.0 — 36 Components
 						</Badge>
-					</div>
+					</motion.div>
 
 					{/* Headline */}
-					<h1
-						className="animate-landing-reveal font-display text-5xl font-bold leading-[1.08] tracking-tight text-foreground sm:text-6xl lg:text-7xl"
-						style={{ animationDelay: "100ms" }}
+					<motion.h1
+						className="font-display text-5xl font-bold leading-[1.08] tracking-tight text-foreground sm:text-6xl lg:text-7xl"
+						variants={fadeInUp}
+						transition={itemTransition}
 					>
 						Build interfaces
 						<br />
 						with <span className="text-primary">clarity</span>,
 						<br />
 						not compromise.
-					</h1>
+					</motion.h1>
 
 					{/* Subtitle */}
-					<p
-						className="animate-landing-reveal mt-6 max-w-xl text-lg text-muted-foreground sm:text-xl"
-						style={{ animationDelay: "200ms" }}
+					<motion.p
+						className="mt-6 max-w-xl text-lg text-muted-foreground sm:text-xl"
+						variants={fadeInUp}
+						transition={itemTransition}
 					>
 						A production-ready React component library built on Tailwind CSS v4. Accessible,
 						themeable, and designed for teams that care about craft.
-					</p>
+					</motion.p>
 
 					{/* CTAs */}
-					<div
-						className="animate-landing-reveal mt-10 flex flex-wrap gap-4"
-						style={{ animationDelay: "300ms" }}
+					<motion.div
+						className="mt-10 flex flex-wrap gap-4"
+						variants={fadeInUp}
+						transition={itemTransition}
 					>
 						<Button size="lg">Get Started</Button>
 						<Button variant="outline" size="lg">
 							View Components
 						</Button>
-					</div>
+					</motion.div>
 
 					{/* Stats row */}
-					<div
-						className="animate-landing-reveal mt-16 flex gap-10 border-t border-border pt-8"
-						style={{ animationDelay: "400ms" }}
+					<motion.div
+						className="mt-16 flex gap-10 border-t border-border pt-8"
+						variants={fadeInUp}
+						transition={itemTransition}
 					>
 						<div>
 							<p className="font-display text-3xl font-bold text-foreground">36</p>
@@ -78,8 +100,8 @@ export function Hero() {
 							<p className="font-display text-3xl font-bold text-foreground">0</p>
 							<p className="text-sm text-muted-foreground">Dependencies</p>
 						</div>
-					</div>
-				</div>
+					</motion.div>
+				</motion.div>
 			</div>
 		</section>
 	);

--- a/src/components/landing/testimonials.tsx
+++ b/src/components/landing/testimonials.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { MotionItem, MotionReveal, MotionStagger } from "@/components/motion";
 import { Avatar } from "@/components/ui/avatar";
 
 const testimonials = [
@@ -29,7 +32,7 @@ export function Testimonials() {
 		<section className="py-24 sm:py-32">
 			<div className="mx-auto max-w-6xl px-6 sm:px-8">
 				{/* Section header */}
-				<div className="mb-16 max-w-2xl">
+				<MotionReveal direction="up" spring="gentle" className="mb-16 max-w-2xl">
 					<p className="mb-3 font-mono text-sm font-medium uppercase tracking-wider text-primary">
 						Testimonials
 					</p>
@@ -38,34 +41,36 @@ export function Testimonials() {
 						<br />
 						who ship.
 					</h2>
-				</div>
+				</MotionReveal>
 
 				{/* Testimonial grid */}
-				<div className="grid gap-8 sm:grid-cols-3">
+				<MotionStagger stagger={0.12} className="grid gap-8 sm:grid-cols-3">
 					{testimonials.map((t) => (
-						<figure key={t.name} className="relative">
-							{/* Oversized quotation mark */}
-							<span
-								className="pointer-events-none absolute -top-4 -left-2 select-none font-display text-7xl leading-none text-primary/10"
-								aria-hidden="true"
-							>
-								&ldquo;
-							</span>
+						<MotionItem key={t.name}>
+							<figure className="relative">
+								{/* Oversized quotation mark */}
+								<span
+									className="pointer-events-none absolute -top-4 -left-2 select-none font-display text-7xl leading-none text-primary/10"
+									aria-hidden="true"
+								>
+									&ldquo;
+								</span>
 
-							<blockquote className="relative text-base leading-relaxed text-foreground">
-								{t.quote}
-							</blockquote>
+								<blockquote className="relative text-base leading-relaxed text-foreground">
+									{t.quote}
+								</blockquote>
 
-							<figcaption className="mt-6 flex items-center gap-3">
-								<Avatar fallback={t.initials} alt={t.name} size="sm" />
-								<div>
-									<p className="text-sm font-medium text-foreground">{t.name}</p>
-									<p className="text-sm text-muted-foreground">{t.role}</p>
-								</div>
-							</figcaption>
-						</figure>
+								<figcaption className="mt-6 flex items-center gap-3">
+									<Avatar fallback={t.initials} alt={t.name} size="sm" />
+									<div>
+										<p className="text-sm font-medium text-foreground">{t.name}</p>
+										<p className="text-sm text-muted-foreground">{t.role}</p>
+									</div>
+								</figcaption>
+							</figure>
+						</MotionItem>
 					))}
-				</div>
+				</MotionStagger>
 			</div>
 		</section>
 	);

--- a/src/components/motion/__tests__/motion.test.tsx
+++ b/src/components/motion/__tests__/motion.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, createRef, forwardRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// ─── Mock motion/react ──────────────────────────────────────────────
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// ─── Import after mock ──────────────────────────────────────────────
+
+import { MotionItem, MotionReveal, MotionStagger } from "../index";
+
+// ─── MotionReveal ───────────────────────────────────────────────────
+
+describe("MotionReveal", () => {
+	it("renders children", () => {
+		render(
+			<MotionReveal>
+				<p>Hello</p>
+			</MotionReveal>,
+		);
+		expect(screen.getByText("Hello")).toBeInTheDocument();
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<MotionReveal ref={ref}>
+				<p>Ref test</p>
+			</MotionReveal>,
+		);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts className", () => {
+		render(
+			<MotionReveal className="custom-class">
+				<p>Styled</p>
+			</MotionReveal>,
+		);
+		const wrapper = screen.getByText("Styled").parentElement;
+		expect(wrapper?.className).toContain("custom-class");
+	});
+
+	it("accepts all direction props", () => {
+		const directions = ["up", "down", "left", "right", "none"] as const;
+		for (const direction of directions) {
+			const { unmount } = render(
+				<MotionReveal direction={direction}>
+					<p>{direction}</p>
+				</MotionReveal>,
+			);
+			expect(screen.getByText(direction)).toBeInTheDocument();
+			unmount();
+		}
+	});
+});
+
+// ─── MotionStagger ──────────────────────────────────────────────────
+
+describe("MotionStagger", () => {
+	it("renders children", () => {
+		render(
+			<MotionStagger>
+				<p>Item 1</p>
+				<p>Item 2</p>
+			</MotionStagger>,
+		);
+		expect(screen.getByText("Item 1")).toBeInTheDocument();
+		expect(screen.getByText("Item 2")).toBeInTheDocument();
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<MotionStagger ref={ref}>
+				<p>Ref test</p>
+			</MotionStagger>,
+		);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts className", () => {
+		render(
+			<MotionStagger className="stagger-grid">
+				<p>Child</p>
+			</MotionStagger>,
+		);
+		const wrapper = screen.getByText("Child").parentElement;
+		expect(wrapper?.className).toContain("stagger-grid");
+	});
+});
+
+// ─── MotionItem ─────────────────────────────────────────────────────
+
+describe("MotionItem", () => {
+	it("renders children", () => {
+		render(
+			<MotionItem>
+				<p>Item content</p>
+			</MotionItem>,
+		);
+		expect(screen.getByText("Item content")).toBeInTheDocument();
+	});
+
+	it("forwards ref", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<MotionItem ref={ref}>
+				<p>Ref test</p>
+			</MotionItem>,
+		);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
+	});
+
+	it("accepts className", () => {
+		render(
+			<MotionItem className="item-class">
+				<p>Styled item</p>
+			</MotionItem>,
+		);
+		const wrapper = screen.getByText("Styled item").parentElement;
+		expect(wrapper?.className).toContain("item-class");
+	});
+
+	it("works inside MotionStagger", () => {
+		render(
+			<MotionStagger>
+				<MotionItem>
+					<p>Staggered 1</p>
+				</MotionItem>
+				<MotionItem>
+					<p>Staggered 2</p>
+				</MotionItem>
+			</MotionStagger>,
+		);
+		expect(screen.getByText("Staggered 1")).toBeInTheDocument();
+		expect(screen.getByText("Staggered 2")).toBeInTheDocument();
+	});
+});

--- a/src/components/motion/index.tsx
+++ b/src/components/motion/index.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { motion, useReducedMotion, type Variants } from "motion/react";
+import { forwardRef, type ReactNode } from "react";
+import {
+	createStaggerContainer,
+	directionVariants,
+	fadeInUp,
+	type RevealDirection,
+	reducedMotionTransition,
+	type SpringPresetName,
+	springs,
+} from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+// ─── MotionReveal ───────────────────────────────────────────────────
+
+export type MotionRevealProps = {
+	/** Animation direction. @default "up" */
+	direction?: RevealDirection;
+	/** Delay before animation starts (seconds). @default 0 */
+	delay?: number;
+	/** Spring preset name from design tokens. @default "gentle" */
+	spring?: SpringPresetName;
+	/** Fraction of element visible before triggering. @default 0.3 */
+	viewportAmount?: number;
+	/** Only animate on first entrance. @default true */
+	once?: boolean;
+	className?: string;
+	children: ReactNode;
+};
+
+/**
+ * Viewport-triggered reveal animation.
+ *
+ * Wraps children in a `motion.div` that animates in when scrolled into view.
+ * Respects `prefers-reduced-motion` by skipping animation entirely.
+ */
+const MotionReveal = forwardRef<HTMLDivElement, MotionRevealProps>(
+	(
+		{
+			direction = "up",
+			delay = 0,
+			spring = "gentle",
+			viewportAmount = 0.3,
+			once = true,
+			className,
+			children,
+		},
+		ref,
+	) => {
+		const shouldReduce = useReducedMotion();
+
+		const variants = directionVariants[direction];
+		const transition = shouldReduce ? reducedMotionTransition : { ...springs[spring], delay };
+
+		return (
+			<motion.div
+				ref={ref}
+				initial="hidden"
+				whileInView="visible"
+				viewport={{ once, amount: viewportAmount }}
+				variants={variants}
+				transition={transition}
+				className={cn(className)}
+			>
+				{children}
+			</motion.div>
+		);
+	},
+);
+MotionReveal.displayName = "MotionReveal";
+
+// ─── MotionStagger ──────────────────────────────────────────────────
+
+export type MotionStaggerProps = {
+	/** Delay between each child animation (seconds). @default 0.1 */
+	stagger?: number;
+	/** Delay before stagger sequence starts (seconds). @default 0.05 */
+	delayChildren?: number;
+	/** Fraction of element visible before triggering. @default 0.3 */
+	viewportAmount?: number;
+	/** Only animate on first entrance. @default true */
+	once?: boolean;
+	className?: string;
+	children: ReactNode;
+};
+
+/**
+ * Stagger container for animating children sequentially.
+ *
+ * Wrap multiple `<MotionItem>` children in this component to create
+ * cascading entrance animations triggered on viewport entry.
+ */
+const MotionStagger = forwardRef<HTMLDivElement, MotionStaggerProps>(
+	(
+		{ stagger = 0.1, delayChildren = 0.05, viewportAmount = 0.3, once = true, className, children },
+		ref,
+	) => {
+		const shouldReduce = useReducedMotion();
+
+		const containerVariants = shouldReduce
+			? { hidden: {}, visible: {} }
+			: createStaggerContainer(stagger, delayChildren);
+
+		return (
+			<motion.div
+				ref={ref}
+				initial="hidden"
+				whileInView="visible"
+				viewport={{ once, amount: viewportAmount }}
+				variants={containerVariants}
+				className={cn(className)}
+			>
+				{children}
+			</motion.div>
+		);
+	},
+);
+MotionStagger.displayName = "MotionStagger";
+
+// ─── MotionItem ─────────────────────────────────────────────────────
+
+export type MotionItemProps = {
+	/** Custom variants override. @default fadeInUp */
+	variants?: Variants;
+	/** Spring preset name. @default "gentle" */
+	spring?: SpringPresetName;
+	className?: string;
+	children: ReactNode;
+};
+
+/**
+ * Child item for use inside `<MotionStagger>`.
+ *
+ * Inherits stagger timing from the parent container. Uses `fadeInUp` by
+ * default but accepts custom variants.
+ */
+const MotionItem = forwardRef<HTMLDivElement, MotionItemProps>(
+	({ variants: customVariants, spring = "gentle", className, children }, ref) => {
+		const shouldReduce = useReducedMotion();
+
+		const itemVariants = customVariants ?? fadeInUp;
+		const transition = shouldReduce ? reducedMotionTransition : springs[spring];
+
+		return (
+			<motion.div
+				ref={ref}
+				variants={itemVariants}
+				transition={transition}
+				className={cn(className)}
+			>
+				{children}
+			</motion.div>
+		);
+	},
+);
+MotionItem.displayName = "MotionItem";
+
+// ─── Exports ────────────────────────────────────────────────────────
+
+export { MotionReveal, MotionStagger, MotionItem };

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,128 @@
+/**
+ * Framer Motion presets — animation variants, spring configs, and helpers.
+ *
+ * Import from `@/lib/motion` in client components. All spring and duration
+ * values are sourced from `@/lib/tokens` to stay aligned with design tokens.
+ */
+
+import type { Transition, Variants } from "motion/react";
+import { durationSeconds, springPresets } from "@/lib/tokens";
+
+export type { SpringPresetName } from "@/lib/tokens";
+// Re-export for convenience so consumers don't need to import from tokens
+export { springPresets } from "@/lib/tokens";
+
+// ─── Spring shortcuts ───────────────────────────────────────────────
+
+export const springs = springPresets;
+
+// ─── Duration shortcuts (seconds) ───────────────────────────────────
+
+export const durations = durationSeconds;
+
+// ─── Variant presets ────────────────────────────────────────────────
+
+export const fadeIn: Variants = {
+	hidden: { opacity: 0 },
+	visible: { opacity: 1 },
+};
+
+export const fadeInUp: Variants = {
+	hidden: { opacity: 0, y: 24 },
+	visible: { opacity: 1, y: 0 },
+};
+
+export const fadeInDown: Variants = {
+	hidden: { opacity: 0, y: -24 },
+	visible: { opacity: 1, y: 0 },
+};
+
+export const fadeInLeft: Variants = {
+	hidden: { opacity: 0, x: -24 },
+	visible: { opacity: 1, x: 0 },
+};
+
+export const fadeInRight: Variants = {
+	hidden: { opacity: 0, x: 24 },
+	visible: { opacity: 1, x: 0 },
+};
+
+export const scaleIn: Variants = {
+	hidden: { opacity: 0, scale: 0.9 },
+	visible: { opacity: 1, scale: 1 },
+};
+
+// ─── Stagger helpers ────────────────────────────────────────────────
+
+/** Container variant that triggers staggered children. */
+export const staggerContainer: Variants = {
+	hidden: {},
+	visible: {
+		transition: {
+			staggerChildren: 0.1,
+			delayChildren: 0.05,
+		},
+	},
+};
+
+/** Create a stagger container with custom timing. */
+export function createStaggerContainer(stagger = 0.1, delayChildren = 0.05): Variants {
+	return {
+		hidden: {},
+		visible: {
+			transition: {
+				staggerChildren: stagger,
+				delayChildren,
+			},
+		},
+	};
+}
+
+// ─── Interaction presets ────────────────────────────────────────────
+
+/** Subtle lift on hover — good for cards and clickable elements. */
+export const hoverLift = {
+	whileHover: { y: -2, transition: springs.snappy },
+	whileTap: { scale: 0.98, transition: springs.snappy },
+} as const;
+
+/** Scale up on hover — good for buttons and icons. */
+export const hoverScale = {
+	whileHover: { scale: 1.03, transition: springs.snappy },
+	whileTap: { scale: 0.97, transition: springs.snappy },
+} as const;
+
+/** Shrink on tap — minimal feedback for touch interactions. */
+export const tapShrink = {
+	whileTap: { scale: 0.95, transition: springs.snappy },
+} as const;
+
+// ─── Viewport defaults ─────────────────────────────────────────────
+
+/** Standard viewport trigger: once, 30% visible. */
+export const viewportOnce = { once: true, amount: 0.3 } as const;
+
+// ─── Reduced motion ────────────────────────────────────────────────
+
+/** Transition override for `prefers-reduced-motion` — instant, no animation. */
+export const reducedMotionTransition: Transition = { duration: 0 };
+
+// ─── SVG path drawing ──────────────────────────────────────────────
+
+/** Animate SVG path from hidden to fully drawn. */
+export const pathDraw: Variants = {
+	hidden: { pathLength: 0, opacity: 0 },
+	visible: { pathLength: 1, opacity: 1 },
+};
+
+// ─── Direction map (used by MotionReveal) ───────────────────────────
+
+export const directionVariants = {
+	up: fadeInUp,
+	down: fadeInDown,
+	left: fadeInLeft,
+	right: fadeInRight,
+	none: fadeIn,
+} as const;
+
+export type RevealDirection = keyof typeof directionVariants;

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -138,6 +138,15 @@ export const duration = {
 
 export type DurationScale = keyof typeof duration;
 
+/** Duration values in seconds — for use with Framer Motion transitions. */
+export const durationSeconds = {
+	instant: 0.05,
+	fast: 0.15,
+	normal: 0.25,
+	slow: 0.4,
+	slower: 0.6,
+} as const satisfies Record<DurationScale, number>;
+
 export const easing = {
 	default: "cubic-bezier(0.2, 0, 0, 1)",
 	spring: "cubic-bezier(0.34, 1.56, 0.64, 1)",
@@ -145,3 +154,26 @@ export const easing = {
 } as const;
 
 export type EasingCurve = keyof typeof easing;
+
+// ─── Spring Presets (Framer Motion) ─────────────────────────────────
+
+export type SpringPreset = {
+	type: "spring";
+	stiffness: number;
+	damping: number;
+	mass?: number;
+};
+
+/** Spring presets for Framer Motion — tuned to complement design tokens. */
+export const springPresets = {
+	/** Snappy — fast, crisp interactions (buttons, toggles) */
+	snappy: { type: "spring" as const, stiffness: 400, damping: 30 },
+	/** Default — balanced, natural motion (general purpose) */
+	default: { type: "spring" as const, stiffness: 200, damping: 24 },
+	/** Gentle — smooth reveals (viewport entrance, fade-ins) */
+	gentle: { type: "spring" as const, stiffness: 80, damping: 14 },
+	/** Bouncy — playful, elastic feel (hero elements, emphasis) */
+	bouncy: { type: "spring" as const, stiffness: 300, damping: 12 },
+} as const satisfies Record<string, SpringPreset>;
+
+export type SpringPresetName = keyof typeof springPresets;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,21 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// Polyfill IntersectionObserver for jsdom (required by Framer Motion's whileInView)
+if (typeof globalThis.IntersectionObserver === "undefined") {
+	globalThis.IntersectionObserver = class IntersectionObserver {
+		readonly root: Element | null = null;
+		readonly rootMargin: string = "0px";
+		readonly thresholds: ReadonlyArray<number> = [0];
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+		takeRecords(): IntersectionObserverEntry[] {
+			return [];
+		}
+	};
+}
+
 afterEach(() => {
 	cleanup();
 });


### PR DESCRIPTION
## Summary
- Add `motion` (Framer Motion v12+) package with animation utility layer
- Create reusable wrapper components: `MotionReveal`, `MotionStagger`, `MotionItem`
- Upgrade landing page (hero, features, testimonials, CTA) with spring physics and viewport-triggered reveals
- Add animation-patterns.md rule file, update 5 agents and 2 skill files with motion awareness
- Add IntersectionObserver polyfill for jsdom test environment

## New Files (4)
| File | Purpose |
|------|---------|
| `src/lib/motion.ts` | Animation presets, spring configs, variant helpers |
| `src/components/motion/index.tsx` | Client-boundary wrapper components |
| `.claude/rules/animation-patterns.md` | CSS vs FM decision matrix, patterns |
| `src/components/motion/__tests__/motion.test.tsx` | Unit tests (11 tests) |

## Modified Files (16)
- `package.json` + `pnpm-lock.yaml` — `motion` dependency
- `src/lib/tokens.ts` — spring presets, duration seconds
- `src/test/setup.ts` — IntersectionObserver polyfill
- `src/components/landing/{hero,features,testimonials,cta-section}.tsx` — FM animations
- `.claude/rules/design-system.md` — expanded Motion section
- `.claude/skills/{frontend-stack,testing}/SKILL.md` — FM patterns
- `.claude/agents/{design-implementer,code-reviewer,test-writer,feature-orchestrator,verify-app}.md` — motion awareness

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (119 files checked, 0 issues)
- [x] `pnpm test:unit` — 321/321 tests pass (11 new motion tests)
- [x] `pnpm build` — production build succeeds
- [x] Pre-commit hooks (biome + typecheck + commitlint) all pass
- [ ] Visual verification: start dev server, scroll landing page, confirm smooth animations
- [ ] Test with `prefers-reduced-motion: reduce` in devtools — animations should be suppressed

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)