### PR TITLE
feat: Creative Agency landing page at /agency

### DIFF
--- a/src/app/agency/page.tsx
+++ b/src/app/agency/page.tsx
@@ -1,0 +1,25 @@
+import { AgencyHero } from "@/components/agency/agency-hero";
+import { ContactSection } from "@/components/agency/contact-section";
+import { ProcessTimeline } from "@/components/agency/process-timeline";
+import { ProjectShowcase } from "@/components/agency/project-showcase";
+import { TeamGrid } from "@/components/agency/team-grid";
+
+export const metadata = {
+	title: "Creative Agency — We Craft Digital Experiences",
+	description:
+		"Strategy, design, and engineering for brands that refuse to blend in. Full-service creative agency with a track record of 120+ projects shipped.",
+};
+
+export default function AgencyPage() {
+	return (
+		<div className="min-h-screen bg-background">
+			<main>
+				<AgencyHero />
+				<ProjectShowcase />
+				<TeamGrid />
+				<ProcessTimeline />
+				<ContactSection />
+			</main>
+		</div>
+	);
+}

--- a/src/components/agency/__tests__/agency-hero.test.tsx
+++ b/src/components/agency/__tests__/agency-hero.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { AgencyHero } from "../agency-hero";
+
+describe("AgencyHero", () => {
+	it("renders the headline text", () => {
+		render(<AgencyHero />);
+		expect(screen.getByText(/We craft/)).toBeInTheDocument();
+		expect(screen.getByText("digital")).toBeInTheDocument();
+		expect(screen.getByText(/experiences/)).toBeInTheDocument();
+	});
+
+	it("renders the eyebrow text", () => {
+		render(<AgencyHero />);
+		expect(screen.getByText("Creative Studio")).toBeInTheDocument();
+	});
+
+	it("renders the subtitle", () => {
+		render(<AgencyHero />);
+		expect(screen.getByText(/Strategy, design, and engineering for brands/)).toBeInTheDocument();
+	});
+
+	it("renders CTA buttons", () => {
+		render(<AgencyHero />);
+		expect(screen.getByRole("button", { name: "View Our Work" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Get in Touch" })).toBeInTheDocument();
+	});
+
+	it("renders stats section", () => {
+		render(<AgencyHero />);
+		expect(screen.getByText("120+")).toBeInTheDocument();
+		expect(screen.getByText("Projects Shipped")).toBeInTheDocument();
+		expect(screen.getByText("8")).toBeInTheDocument();
+		expect(screen.getByText("Years Running")).toBeInTheDocument();
+		expect(screen.getByText("40+")).toBeInTheDocument();
+		expect(screen.getByText("Global Clients")).toBeInTheDocument();
+	});
+
+	it("marks decorative parallax layers as aria-hidden", () => {
+		const { container } = render(<AgencyHero />);
+		const hiddenElements = container.querySelectorAll("[aria-hidden='true']");
+		expect(hiddenElements.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it("accepts and applies className", () => {
+		const { container } = render(<AgencyHero className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section?.className).toContain("custom-class");
+	});
+});

--- a/src/components/agency/__tests__/contact-section.test.tsx
+++ b/src/components/agency/__tests__/contact-section.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ContactSection } from "../contact-section";
+
+describe("ContactSection", () => {
+	it("renders the section heading", () => {
+		render(<ContactSection />);
+		expect(screen.getByText("Get in Touch")).toBeInTheDocument();
+		expect(screen.getByText(/remarkable together/)).toBeInTheDocument();
+	});
+
+	it("renders all form fields with labels", () => {
+		render(<ContactSection />);
+		expect(screen.getByLabelText("Name")).toBeInTheDocument();
+		expect(screen.getByLabelText("Email")).toBeInTheDocument();
+		expect(screen.getByLabelText("Message")).toBeInTheDocument();
+	});
+
+	it("renders the submit button", () => {
+		render(<ContactSection />);
+		expect(screen.getByRole("button", { name: "Send Message" })).toBeInTheDocument();
+	});
+
+	it("renders the divider", () => {
+		const { container } = render(<ContactSection />);
+		const hr = container.querySelector("hr");
+		expect(hr).toBeInTheDocument();
+	});
+
+	it("renders form with correct input types", () => {
+		render(<ContactSection />);
+		const emailInput = screen.getByLabelText("Email");
+		expect(emailInput).toHaveAttribute("type", "email");
+	});
+
+	it("renders the description text", () => {
+		render(<ContactSection />);
+		expect(screen.getByText(/Have a project in mind/)).toBeInTheDocument();
+	});
+
+	it("accepts and applies className", () => {
+		const { container } = render(<ContactSection className="test-class" />);
+		const section = container.querySelector("section");
+		expect(section?.className).toContain("test-class");
+	});
+});

--- a/src/components/agency/__tests__/process-timeline.test.tsx
+++ b/src/components/agency/__tests__/process-timeline.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ProcessTimeline } from "../process-timeline";
+
+describe("ProcessTimeline", () => {
+	it("renders the section heading", () => {
+		render(<ProcessTimeline />);
+		expect(screen.getByText("Our Process")).toBeInTheDocument();
+		expect(screen.getByText("How we work")).toBeInTheDocument();
+	});
+
+	it("renders all 5 process steps", () => {
+		render(<ProcessTimeline />);
+		expect(screen.getByText("Discovery")).toBeInTheDocument();
+		expect(screen.getByText("Concept")).toBeInTheDocument();
+		expect(screen.getByText("Design")).toBeInTheDocument();
+		expect(screen.getByText("Build")).toBeInTheDocument();
+		expect(screen.getByText("Launch")).toBeInTheDocument();
+	});
+
+	it("renders step numbers", () => {
+		render(<ProcessTimeline />);
+		expect(screen.getByText("01")).toBeInTheDocument();
+		expect(screen.getByText("02")).toBeInTheDocument();
+		expect(screen.getByText("03")).toBeInTheDocument();
+		expect(screen.getByText("04")).toBeInTheDocument();
+		expect(screen.getByText("05")).toBeInTheDocument();
+	});
+
+	it("renders step descriptions", () => {
+		render(<ProcessTimeline />);
+		expect(screen.getByText(/We dive deep into your brand/)).toBeInTheDocument();
+		expect(screen.getByText(/Wireframes, moodboards, and prototypes/)).toBeInTheDocument();
+		expect(screen.getByText(/Pixel-perfect interfaces/)).toBeInTheDocument();
+		expect(screen.getByText(/Clean, performant code/)).toBeInTheDocument();
+		expect(screen.getByText(/Thorough QA, performance optimization/)).toBeInTheDocument();
+	});
+
+	it("renders the SVG connecting line container", () => {
+		const { container } = render(<ProcessTimeline />);
+		const svg = container.querySelector("svg");
+		expect(svg).toBeInTheDocument();
+	});
+
+	it("marks the SVG line container as aria-hidden", () => {
+		const { container } = render(<ProcessTimeline />);
+		const hiddenLine = container.querySelector("[aria-hidden='true']");
+		expect(hiddenLine).toBeInTheDocument();
+	});
+
+	it("accepts and applies className", () => {
+		const { container } = render(<ProcessTimeline className="test-class" />);
+		const section = container.querySelector("section");
+		expect(section?.className).toContain("test-class");
+	});
+});

--- a/src/components/agency/__tests__/project-showcase.test.tsx
+++ b/src/components/agency/__tests__/project-showcase.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock matchMedia for JSDOM (not available by default)
+beforeEach(() => {
+	Object.defineProperty(window, "matchMedia", {
+		writable: true,
+		configurable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+});
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: string[]) => ({
+		get: () => output?.[0] ?? "0%",
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ProjectShowcase } from "../project-showcase";
+
+describe("ProjectShowcase", () => {
+	it("renders the section heading", () => {
+		render(<ProjectShowcase />);
+		expect(screen.getByText("Selected Work")).toBeInTheDocument();
+		expect(screen.getByText("Projects that speak")).toBeInTheDocument();
+	});
+
+	it("renders all 5 project titles", () => {
+		render(<ProjectShowcase />);
+		expect(screen.getByText("Lumina Rebrand")).toBeInTheDocument();
+		expect(screen.getByText("Vertex Dashboard")).toBeInTheDocument();
+		expect(screen.getByText("Nomad Social")).toBeInTheDocument();
+		expect(screen.getByText("Echo Music")).toBeInTheDocument();
+		expect(screen.getByText("Arc Architecture")).toBeInTheDocument();
+	});
+
+	it("renders category badges for each project", () => {
+		render(<ProjectShowcase />);
+		expect(screen.getByText("Branding")).toBeInTheDocument();
+		expect(screen.getByText("Product Design")).toBeInTheDocument();
+		expect(screen.getByText("App Development")).toBeInTheDocument();
+		expect(screen.getByText("Web Experience")).toBeInTheDocument();
+		expect(screen.getByText("Website")).toBeInTheDocument();
+	});
+
+	it("renders in grid layout by default (mobile/SSR fallback)", () => {
+		// In JSDOM, matchMedia defaults to not matching, so isDesktop = false
+		// which means it renders the vertical grid
+		const { container } = render(<ProjectShowcase />);
+		const grid = container.querySelector(".grid");
+		expect(grid).toBeInTheDocument();
+	});
+
+	it("marks gradient placeholders as aria-hidden", () => {
+		const { container } = render(<ProjectShowcase />);
+		const hiddenElements = container.querySelectorAll("[aria-hidden='true']");
+		expect(hiddenElements.length).toBeGreaterThanOrEqual(5);
+	});
+
+	it("accepts and applies className", () => {
+		const { container } = render(<ProjectShowcase className="test-class" />);
+		const section = container.querySelector("section");
+		expect(section?.className).toContain("test-class");
+	});
+});

--- a/src/components/agency/__tests__/team-grid.test.tsx
+++ b/src/components/agency/__tests__/team-grid.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { TeamGrid } from "../team-grid";
+
+describe("TeamGrid", () => {
+	it("renders the section heading", () => {
+		render(<TeamGrid />);
+		expect(screen.getByText("The Team")).toBeInTheDocument();
+		expect(screen.getByText("People behind the pixels")).toBeInTheDocument();
+	});
+
+	it("renders all 6 team members", () => {
+		render(<TeamGrid />);
+		expect(screen.getByText("Ava Chen")).toBeInTheDocument();
+		expect(screen.getByText("Marcus Rivera")).toBeInTheDocument();
+		expect(screen.getByText("Sofia Andersson")).toBeInTheDocument();
+		expect(screen.getByText("James Okafor")).toBeInTheDocument();
+		expect(screen.getByText("Lena Park")).toBeInTheDocument();
+		expect(screen.getByText("Daniel Torres")).toBeInTheDocument();
+	});
+
+	it("renders role badges for each member", () => {
+		render(<TeamGrid />);
+		expect(screen.getByText("Creative Director")).toBeInTheDocument();
+		expect(screen.getByText("Lead Engineer")).toBeInTheDocument();
+		expect(screen.getByText("UX Strategist")).toBeInTheDocument();
+		expect(screen.getByText("Motion Designer")).toBeInTheDocument();
+		expect(screen.getByText("Brand Designer")).toBeInTheDocument();
+		expect(screen.getByText("Project Lead")).toBeInTheDocument();
+	});
+
+	it("renders 6 avatar components", () => {
+		const { container } = render(<TeamGrid />);
+		// Radix Avatar renders <span> root elements with the avatar variant classes
+		const avatars = container.querySelectorAll(".rounded-full.border.border-border");
+		expect(avatars.length).toBe(6);
+	});
+
+	it("renders bio text for each member", () => {
+		render(<TeamGrid />);
+		expect(screen.getByText(/15 years shaping brand identities/)).toBeInTheDocument();
+		expect(screen.getByText(/Full-stack architect/)).toBeInTheDocument();
+	});
+
+	it("marks decorative hover gradients as aria-hidden", () => {
+		const { container } = render(<TeamGrid />);
+		const hiddenElements = container.querySelectorAll("[aria-hidden='true']");
+		expect(hiddenElements.length).toBeGreaterThanOrEqual(6);
+	});
+
+	it("accepts and applies className", () => {
+		const { container } = render(<TeamGrid className="test-class" />);
+		const section = container.querySelector("section");
+		expect(section?.className).toContain("test-class");
+	});
+});

--- a/src/components/agency/agency-hero.tsx
+++ b/src/components/agency/agency-hero.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { motion, useReducedMotion, useScroll, useTransform } from "motion/react";
+import { useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { createStaggerContainer, fadeInUp, reducedMotionTransition, springs } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+type AgencyHeroProps = {
+	className?: string;
+};
+
+export function AgencyHero({ className }: AgencyHeroProps) {
+	const shouldReduce = useReducedMotion();
+	const sectionRef = useRef<HTMLElement>(null);
+
+	const { scrollYProgress } = useScroll({
+		target: sectionRef,
+		offset: ["start start", "end start"],
+	});
+
+	const bgY = useTransform(scrollYProgress, [0, 1], [0, -40]);
+	const midY = useTransform(scrollYProgress, [0, 1], [0, -100]);
+	const fgY = useTransform(scrollYProgress, [0, 1], [0, -200]);
+
+	const containerVariants = shouldReduce
+		? { hidden: {}, visible: {} }
+		: createStaggerContainer(0.12, 0.15);
+
+	const itemTransition = shouldReduce ? reducedMotionTransition : springs.gentle;
+
+	return (
+		<section
+			ref={sectionRef}
+			className={cn(
+				"relative flex min-h-screen items-center overflow-hidden bg-background",
+				className,
+			)}
+		>
+			{/* Background parallax layer — deep, slow-moving gradient orbs */}
+			<motion.div
+				className="pointer-events-none absolute inset-0 -z-30"
+				style={{ y: shouldReduce ? 0 : bgY }}
+				aria-hidden="true"
+			>
+				<div
+					className="absolute -left-32 -top-32 h-[600px] w-[600px] rounded-full opacity-20 blur-[100px]"
+					style={{
+						background: "radial-gradient(circle, var(--primary) 0%, transparent 70%)",
+					}}
+				/>
+				<div
+					className="absolute -bottom-48 right-0 h-[500px] w-[500px] rounded-full opacity-15 blur-[80px]"
+					style={{
+						background: "radial-gradient(circle, var(--accent) 0%, transparent 70%)",
+					}}
+				/>
+			</motion.div>
+
+			{/* Mid parallax layer — geometric shapes */}
+			<motion.div
+				className="pointer-events-none absolute inset-0 -z-20"
+				style={{ y: shouldReduce ? 0 : midY }}
+				aria-hidden="true"
+			>
+				<div className="absolute left-[15%] top-[20%] h-64 w-64 rotate-45 rounded-3xl border border-primary/10 opacity-40" />
+				<div className="absolute bottom-[25%] right-[10%] h-48 w-48 rounded-full border border-accent/10 opacity-30" />
+				<div className="absolute left-[60%] top-[60%] h-32 w-32 rotate-12 rounded-xl border border-primary/15 opacity-25" />
+			</motion.div>
+
+			{/* Foreground parallax layer — small decorative elements */}
+			<motion.div
+				className="pointer-events-none absolute inset-0 -z-10"
+				style={{ y: shouldReduce ? 0 : fgY }}
+				aria-hidden="true"
+			>
+				<div className="absolute left-[70%] top-[15%] h-3 w-3 rounded-full bg-primary opacity-60" />
+				<div className="absolute left-[25%] top-[75%] h-2 w-2 rounded-full bg-accent opacity-50" />
+				<div className="absolute left-[80%] top-[65%] h-4 w-4 rounded-full bg-primary/40 opacity-40" />
+			</motion.div>
+
+			{/* Content */}
+			<div className="mx-auto w-full max-w-6xl px-6 py-32 sm:px-8">
+				<motion.div
+					className="max-w-3xl"
+					initial="hidden"
+					whileInView="visible"
+					viewport={{ once: true, amount: 0.2 }}
+					variants={containerVariants}
+				>
+					<motion.p
+						className="mb-4 text-sm font-medium uppercase tracking-[0.2em] text-primary"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						Creative Studio
+					</motion.p>
+
+					<motion.h1
+						className="font-display text-5xl font-bold leading-[1.05] tracking-tight text-foreground sm:text-6xl lg:text-7xl"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						We craft
+						<br />
+						<span className="text-primary">digital</span> experiences
+					</motion.h1>
+
+					<motion.p
+						className="mt-6 max-w-xl text-lg text-muted-foreground sm:text-xl"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						Strategy, design, and engineering for brands that refuse to blend in. We build the
+						digital products people remember.
+					</motion.p>
+
+					<motion.div
+						className="mt-10 flex flex-wrap gap-4"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						<Button size="lg">View Our Work</Button>
+						<Button variant="outline" size="lg">
+							Get in Touch
+						</Button>
+					</motion.div>
+
+					<motion.div
+						className="mt-16 flex gap-10 border-t border-border pt-8"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						<div>
+							<p className="font-display text-3xl font-bold text-foreground">120+</p>
+							<p className="text-sm text-muted-foreground">Projects Shipped</p>
+						</div>
+						<div>
+							<p className="font-display text-3xl font-bold text-foreground">8</p>
+							<p className="text-sm text-muted-foreground">Years Running</p>
+						</div>
+						<div>
+							<p className="font-display text-3xl font-bold text-foreground">40+</p>
+							<p className="text-sm text-muted-foreground">Global Clients</p>
+						</div>
+					</motion.div>
+				</motion.div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/agency/contact-section.tsx
+++ b/src/components/agency/contact-section.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import { MotionItem, MotionReveal, MotionStagger } from "@/components/motion";
+import { Button } from "@/components/ui/button";
+import { Divider } from "@/components/ui/divider";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+type ContactSectionProps = {
+	className?: string;
+};
+
+export function ContactSection({ className }: ContactSectionProps) {
+	useReducedMotion();
+
+	return (
+		<section className={cn("pb-24", className)}>
+			<div className="mx-auto max-w-6xl px-6 sm:px-8">
+				<Divider className="mb-24" />
+
+				<div className="grid grid-cols-1 gap-16 lg:grid-cols-2">
+					{/* Left column — heading */}
+					<MotionReveal direction="up" spring="gentle">
+						<p className="mb-2 text-sm font-medium uppercase tracking-[0.2em] text-primary">
+							Get in Touch
+						</p>
+						<h2 className="font-display text-3xl font-bold text-foreground sm:text-4xl">
+							Let&apos;s build something
+							<br />
+							remarkable together
+						</h2>
+						<p className="mt-4 max-w-md text-muted-foreground">
+							Have a project in mind? We would love to hear about it. Drop us a line and we will get
+							back to you within 24 hours.
+						</p>
+					</MotionReveal>
+
+					{/* Right column — form */}
+					<MotionStagger stagger={0.08}>
+						<form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
+							<MotionItem>
+								<Input label="Name" placeholder="Your full name" />
+							</MotionItem>
+
+							<MotionItem>
+								<Input label="Email" type="email" placeholder="you@company.com" />
+							</MotionItem>
+
+							<MotionItem>
+								<Textarea label="Message" placeholder="Tell us about your project..." rows={5} />
+							</MotionItem>
+
+							<MotionItem>
+								<Button type="submit" size="lg" className="w-full sm:w-auto">
+									Send Message
+								</Button>
+							</MotionItem>
+						</form>
+					</MotionStagger>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/agency/process-timeline.tsx
+++ b/src/components/agency/process-timeline.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { MotionReveal } from "@/components/motion";
+import { pathDraw, reducedMotionTransition, springs, viewportOnce } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+const steps = [
+	{
+		number: "01",
+		title: "Discovery",
+		description:
+			"We dive deep into your brand, audience, and goals. Research and strategy lay the foundation for everything that follows.",
+	},
+	{
+		number: "02",
+		title: "Concept",
+		description:
+			"Wireframes, moodboards, and prototypes come together to define the direction. We iterate until the vision is clear.",
+	},
+	{
+		number: "03",
+		title: "Design",
+		description:
+			"Pixel-perfect interfaces, motion design, and visual systems are crafted with care and attention to every detail.",
+	},
+	{
+		number: "04",
+		title: "Build",
+		description:
+			"Clean, performant code brings designs to life. We build for scale, accessibility, and long-term maintainability.",
+	},
+	{
+		number: "05",
+		title: "Launch",
+		description:
+			"Thorough QA, performance optimization, and strategic rollout ensure a smooth go-live and measurable results.",
+	},
+];
+
+type ProcessTimelineProps = {
+	className?: string;
+};
+
+export function ProcessTimeline({ className }: ProcessTimelineProps) {
+	const shouldReduce = useReducedMotion();
+
+	const lineTransition = shouldReduce
+		? reducedMotionTransition
+		: { ...springs.gentle, duration: 1.5, delay: 0.3 };
+
+	return (
+		<section className={cn("py-24", className)}>
+			<div className="mx-auto max-w-6xl px-6 sm:px-8">
+				<MotionReveal direction="up" spring="gentle">
+					<p className="mb-2 text-sm font-medium uppercase tracking-[0.2em] text-primary">
+						Our Process
+					</p>
+					<h2 className="font-display text-3xl font-bold text-foreground sm:text-4xl">
+						How we work
+					</h2>
+					<p className="mt-3 max-w-lg text-muted-foreground">
+						A proven process refined over hundreds of projects. Every phase has a purpose; nothing
+						is wasted.
+					</p>
+				</MotionReveal>
+
+				<div className="relative mt-16">
+					{/* SVG connecting line */}
+					<div className="absolute left-6 top-0 hidden h-full w-px md:block" aria-hidden="true">
+						<svg className="h-full w-full overflow-visible" preserveAspectRatio="none" role="none">
+							<motion.line
+								x1="0"
+								y1="0"
+								x2="0"
+								y2="100%"
+								stroke="var(--primary)"
+								strokeWidth="2"
+								strokeLinecap="round"
+								variants={pathDraw}
+								initial="hidden"
+								whileInView="visible"
+								viewport={viewportOnce}
+								transition={lineTransition}
+							/>
+						</svg>
+					</div>
+
+					{/* Steps */}
+					<div className="space-y-12 md:space-y-16">
+						{steps.map((step, index) => (
+							<MotionReveal key={step.number} direction="up" delay={index * 0.1} spring="gentle">
+								<div className="flex gap-6 md:gap-10">
+									{/* Step number circle */}
+									<div className="relative z-10 flex h-12 w-12 shrink-0 items-center justify-center rounded-full border-2 border-primary bg-background font-display text-sm font-bold text-primary">
+										{step.number}
+									</div>
+
+									{/* Step content */}
+									<div className="pb-2 pt-2">
+										<h3 className="font-display text-xl font-bold text-foreground">{step.title}</h3>
+										<p className="mt-2 max-w-md text-muted-foreground">{step.description}</p>
+									</div>
+								</div>
+							</MotionReveal>
+						))}
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/agency/project-showcase.tsx
+++ b/src/components/agency/project-showcase.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { motion, useReducedMotion, useScroll, useTransform } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+import { MotionReveal } from "@/components/motion";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const projects = [
+	{
+		title: "Lumina Rebrand",
+		description: "Full brand identity and e-commerce platform for a luxury skincare line.",
+		category: "Branding",
+		gradient: "from-purple-600/80 to-fuchsia-500/80",
+	},
+	{
+		title: "Vertex Dashboard",
+		description:
+			"Real-time analytics dashboard for a fintech startup processing millions of transactions.",
+		category: "Product Design",
+		gradient: "from-blue-600/80 to-cyan-400/80",
+	},
+	{
+		title: "Nomad Social",
+		description: "Mobile-first social platform connecting remote workers across the globe.",
+		category: "App Development",
+		gradient: "from-amber-500/80 to-orange-600/80",
+	},
+	{
+		title: "Echo Music",
+		description:
+			"Interactive web experience for an independent record label and artist collective.",
+		category: "Web Experience",
+		gradient: "from-emerald-500/80 to-teal-600/80",
+	},
+	{
+		title: "Arc Architecture",
+		description: "Portfolio and booking system for an award-winning architectural firm.",
+		category: "Website",
+		gradient: "from-rose-500/80 to-pink-600/80",
+	},
+];
+
+type ProjectShowcaseProps = {
+	className?: string;
+};
+
+export function ProjectShowcase({ className }: ProjectShowcaseProps) {
+	const shouldReduce = useReducedMotion();
+	const [isDesktop, setIsDesktop] = useState(false);
+	const outerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const mql = window.matchMedia("(min-width: 768px)");
+		setIsDesktop(mql.matches);
+
+		const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+		mql.addEventListener("change", handler);
+		return () => mql.removeEventListener("change", handler);
+	}, []);
+
+	const { scrollYProgress } = useScroll({
+		target: outerRef,
+		offset: ["start start", "end end"],
+	});
+
+	const translatePercent = `${((projects.length - 1) * 100) / projects.length}%`;
+	const x = useTransform(scrollYProgress, [0, 1], ["0%", `-${translatePercent}`]);
+
+	const useHorizontalScroll = isDesktop && !shouldReduce;
+
+	return (
+		<section className={cn("relative", className)}>
+			{/* Section header */}
+			<div className="mx-auto max-w-6xl px-6 pt-24 sm:px-8">
+				<MotionReveal direction="up" spring="gentle">
+					<p className="mb-2 text-sm font-medium uppercase tracking-[0.2em] text-primary">
+						Selected Work
+					</p>
+					<h2 className="font-display text-3xl font-bold text-foreground sm:text-4xl">
+						Projects that speak
+					</h2>
+					<p className="mt-3 max-w-lg text-muted-foreground">
+						A curated selection of recent projects across brand, product, and experience design.
+					</p>
+				</MotionReveal>
+			</div>
+
+			{useHorizontalScroll ? (
+				/* Horizontal scroll — desktop only, motion enabled */
+				<div
+					ref={outerRef}
+					style={{ height: `${projects.length * 100}vh` }}
+					className="relative mt-12"
+				>
+					<div className="sticky top-0 flex h-screen items-center overflow-hidden">
+						<motion.div
+							className="flex gap-8 pl-[max(1.5rem,calc((100vw-72rem)/2+1.5rem))]"
+							style={{ x }}
+						>
+							{projects.map((project) => (
+								<div key={project.title} className="w-[min(80vw,500px)] shrink-0">
+									<Card className="h-full overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm">
+										<div
+											className={cn(
+												"flex h-56 items-center justify-center bg-gradient-to-br sm:h-64",
+												project.gradient,
+											)}
+											aria-hidden="true"
+										>
+											<div className="h-16 w-16 rounded-2xl border-2 border-white/30 bg-white/10 backdrop-blur-sm" />
+										</div>
+										<CardHeader>
+											<div className="flex items-center justify-between">
+												<CardTitle>{project.title}</CardTitle>
+												<Badge>{project.category}</Badge>
+											</div>
+										</CardHeader>
+										<CardContent>
+											<CardDescription>{project.description}</CardDescription>
+										</CardContent>
+									</Card>
+								</div>
+							))}
+						</motion.div>
+					</div>
+				</div>
+			) : (
+				/* Vertical grid — mobile or reduced motion */
+				<div className="mx-auto mt-12 grid max-w-6xl grid-cols-1 gap-6 px-6 pb-24 sm:grid-cols-2 sm:px-8 lg:grid-cols-3">
+					{projects.map((project) => (
+						<Card key={project.title} className="overflow-hidden border-border/50 bg-card/80">
+							<div
+								className={cn(
+									"flex h-44 items-center justify-center bg-gradient-to-br",
+									project.gradient,
+								)}
+								aria-hidden="true"
+							>
+								<div className="h-12 w-12 rounded-xl border-2 border-white/30 bg-white/10 backdrop-blur-sm" />
+							</div>
+							<CardHeader>
+								<div className="flex items-center justify-between">
+									<CardTitle>{project.title}</CardTitle>
+									<Badge>{project.category}</Badge>
+								</div>
+							</CardHeader>
+							<CardContent>
+								<CardDescription>{project.description}</CardDescription>
+							</CardContent>
+						</Card>
+					))}
+				</div>
+			)}
+		</section>
+	);
+}

--- a/src/components/agency/team-grid.tsx
+++ b/src/components/agency/team-grid.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { MotionItem, MotionStagger } from "@/components/motion";
+import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { springs } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+const teamMembers = [
+	{
+		name: "Ava Chen",
+		initials: "AC",
+		role: "Creative Director",
+		bio: "15 years shaping brand identities for Fortune 500 companies and ambitious startups alike.",
+	},
+	{
+		name: "Marcus Rivera",
+		initials: "MR",
+		role: "Lead Engineer",
+		bio: "Full-stack architect with a passion for performance, accessibility, and elegant code.",
+	},
+	{
+		name: "Sofia Andersson",
+		initials: "SA",
+		role: "UX Strategist",
+		bio: "Research-driven designer who transforms complex problems into intuitive experiences.",
+	},
+	{
+		name: "James Okafor",
+		initials: "JO",
+		role: "Motion Designer",
+		bio: "Crafts animations and micro-interactions that bring interfaces to life with purpose.",
+	},
+	{
+		name: "Lena Park",
+		initials: "LP",
+		role: "Brand Designer",
+		bio: "Visual storyteller specializing in identity systems, typography, and art direction.",
+	},
+	{
+		name: "Daniel Torres",
+		initials: "DT",
+		role: "Project Lead",
+		bio: "Keeps teams aligned and projects on track from kickoff to launch and beyond.",
+	},
+];
+
+type TeamGridProps = {
+	className?: string;
+};
+
+export function TeamGrid({ className }: TeamGridProps) {
+	const shouldReduce = useReducedMotion();
+
+	return (
+		<section className={cn("py-24", className)}>
+			<div className="mx-auto max-w-6xl px-6 sm:px-8">
+				<div className="mb-12">
+					<p className="mb-2 text-sm font-medium uppercase tracking-[0.2em] text-primary">
+						The Team
+					</p>
+					<h2 className="font-display text-3xl font-bold text-foreground sm:text-4xl">
+						People behind the pixels
+					</h2>
+					<p className="mt-3 max-w-lg text-muted-foreground">
+						A tight-knit crew of designers, engineers, and strategists who believe great work starts
+						with great collaboration.
+					</p>
+				</div>
+
+				<MotionStagger
+					stagger={0.08}
+					className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+				>
+					{teamMembers.map((member) => (
+						<MotionItem key={member.name}>
+							<motion.div
+								className="group relative overflow-hidden rounded-xl border border-border bg-card p-6 transition-colors hover:border-primary/30"
+								{...(shouldReduce ? {} : { whileHover: { scale: 1.03 } })}
+								transition={springs.snappy}
+							>
+								<div className="flex items-start gap-4">
+									<Avatar fallback={member.initials} size="lg" />
+									<div className="min-w-0 flex-1">
+										<h3 className="font-display text-base font-semibold text-foreground">
+											{member.name}
+										</h3>
+										<Badge className="mt-1">{member.role}</Badge>
+									</div>
+								</div>
+
+								{/* Hover overlay with bio */}
+								<div className="mt-4 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+									<p className="text-sm text-muted-foreground">{member.bio}</p>
+								</div>
+
+								{/* Subtle gradient accent on hover */}
+								<div
+									className="pointer-events-none absolute inset-0 -z-10 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+									style={{
+										background:
+											"radial-gradient(circle at bottom right, var(--primary) 0%, transparent 60%)",
+										opacity: 0.05,
+									}}
+									aria-hidden="true"
+								/>
+							</motion.div>
+						</MotionItem>
+					))}
+				</MotionStagger>
+			</div>
+		</section>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a full Creative Agency landing page at `/agency` with five animated sections
- **Parallax Hero**: 3 depth layers with `useScroll` + `useTransform`, gradient orbs, geometric shapes, and CTA buttons
- **Horizontal Scroll Showcase**: Scroll-linked horizontal card strip on desktop, vertical grid fallback on mobile (<768px) and when `prefers-reduced-motion` is active
- **Team Grid**: 6 member cards with `MotionStagger`/`MotionItem` entrance, `Avatar` fallback initials, role badges, and CSS hover overlays for bios
- **Process Timeline**: 5 steps with SVG `motion.line` drawing animation using `pathDraw` variant, `MotionReveal` for each step
- **Contact Form**: Staggered field entrance with `Input`, `Textarea`, `Button` components, `Divider` separator
- All sections call `useReducedMotion()` and disable animations when true
- All decorative elements use `aria-hidden="true"`
- 34 unit tests across 5 test files (all passing)

Closes #98

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (Biome check clean)
- [x] `pnpm test:unit` — all 355 tests pass (53 files, including 5 new agency test files)
- [x] `pnpm build` — production build succeeds with `/agency` route listed
- [ ] Visual verification: visit `/agency` locally and confirm parallax, horizontal scroll, timeline animation, and contact form
- [ ] Responsive check: verify mobile grid fallback at <768px viewport
- [ ] Reduced motion check: enable `prefers-reduced-motion` and confirm animations are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)