### PR TITLE
feat: add SaaS Pricing landing page at /pricing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -337,3 +337,21 @@ body {
 .animate-landing-pulse {
 	animation: landing-pulse-ring 4s ease-in-out infinite;
 }
+
+/* ═══════════════════════════════════════════════════
+   Marquee Animation (Pricing Page)
+   Infinite horizontal scroll for logo strip
+   ═══════════════════════════════════════════════════ */
+
+@keyframes marquee-scroll {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(-50%);
+	}
+}
+
+.animate-marquee {
+	animation: marquee-scroll 30s linear infinite;
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,30 @@
+import { FeatureComparison } from "@/components/pricing/feature-comparison";
+import { LogoMarquee } from "@/components/pricing/logo-marquee";
+import { PricingCards } from "@/components/pricing/pricing-cards";
+import { PricingCta } from "@/components/pricing/pricing-cta";
+import { PricingFaq } from "@/components/pricing/pricing-faq";
+import { PricingHero } from "@/components/pricing/pricing-hero";
+import { ScrollProgress } from "@/components/pricing/scroll-progress";
+
+export const metadata = {
+	title: "Pricing — Simple plans for every team",
+	description:
+		"Start free and scale as you grow. Transparent pricing with no hidden fees for individuals, teams, and enterprises.",
+};
+
+export default function PricingPage() {
+	return (
+		<div className="min-h-screen">
+			<ScrollProgress />
+
+			<main>
+				<PricingHero />
+				<LogoMarquee />
+				<PricingCards />
+				<FeatureComparison />
+				<PricingFaq />
+				<PricingCta />
+			</main>
+		</div>
+	);
+}

--- a/src/components/pricing/__tests__/feature-comparison.test.tsx
+++ b/src/components/pricing/__tests__/feature-comparison.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { FeatureComparison } from "../feature-comparison";
+
+describe("FeatureComparison", () => {
+	it("renders the section heading", () => {
+		render(<FeatureComparison />);
+		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Compare plans");
+	});
+
+	it("renders tier column headers", () => {
+		render(<FeatureComparison />);
+		expect(screen.getByText("Starter")).toBeInTheDocument();
+		expect(screen.getByText("Pro")).toBeInTheDocument();
+		expect(screen.getByText("Enterprise")).toBeInTheDocument();
+	});
+
+	it("renders section titles", () => {
+		render(<FeatureComparison />);
+		expect(screen.getByText("Core")).toBeInTheDocument();
+		expect(screen.getByText("Collaboration")).toBeInTheDocument();
+		expect(screen.getByText("Support")).toBeInTheDocument();
+	});
+
+	it("renders feature rows", () => {
+		render(<FeatureComparison />);
+		expect(screen.getByText("Projects")).toBeInTheDocument();
+		expect(screen.getByText("Storage")).toBeInTheDocument();
+		expect(screen.getByText("API access")).toBeInTheDocument();
+		expect(screen.getByText("Team members")).toBeInTheDocument();
+	});
+
+	it("renders check icons for included features", () => {
+		render(<FeatureComparison />);
+		const includedIcons = screen.getAllByLabelText("Included");
+		expect(includedIcons.length).toBeGreaterThan(0);
+	});
+
+	it("renders dash icons for excluded features", () => {
+		render(<FeatureComparison />);
+		const excludedIcons = screen.getAllByLabelText("Not included");
+		expect(excludedIcons.length).toBeGreaterThan(0);
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<FeatureComparison className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/__tests__/logo-marquee.test.tsx
+++ b/src/components/pricing/__tests__/logo-marquee.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { LogoMarquee } from "../logo-marquee";
+
+describe("LogoMarquee", () => {
+	it("renders the trust label", () => {
+		render(<LogoMarquee />);
+		expect(screen.getByText(/Trusted by teams at/)).toBeInTheDocument();
+	});
+
+	it("renders company names", () => {
+		render(<LogoMarquee />);
+		// Each company appears twice (original + duplicate for seamless loop)
+		expect(screen.getAllByText("Vercel")).toHaveLength(2);
+		expect(screen.getAllByText("Stripe")).toHaveLength(2);
+		expect(screen.getAllByText("Linear")).toHaveLength(2);
+	});
+
+	it("renders duplicated set for seamless loop", () => {
+		const { container } = render(<LogoMarquee />);
+		const duplicateContainer = container.querySelector("[aria-hidden='true']");
+		expect(duplicateContainer).toBeInTheDocument();
+	});
+
+	it("has a marquee role for accessibility", () => {
+		render(<LogoMarquee />);
+		expect(screen.getByRole("marquee")).toBeInTheDocument();
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<LogoMarquee className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/__tests__/pricing-cards.test.tsx
+++ b/src/components/pricing/__tests__/pricing-cards.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { PricingCards } from "../pricing-cards";
+
+describe("PricingCards", () => {
+	it("renders three tier names", () => {
+		render(<PricingCards />);
+		expect(screen.getByText("Starter")).toBeInTheDocument();
+		expect(screen.getByText("Pro")).toBeInTheDocument();
+		expect(screen.getByText("Enterprise")).toBeInTheDocument();
+	});
+
+	it("renders monthly prices by default", () => {
+		render(<PricingCards />);
+		expect(screen.getByText("$0")).toBeInTheDocument();
+		expect(screen.getByText("$29")).toBeInTheDocument();
+		expect(screen.getByText("Custom")).toBeInTheDocument();
+	});
+
+	it("shows Popular badge on Pro tier", () => {
+		render(<PricingCards />);
+		expect(screen.getByText("Popular")).toBeInTheDocument();
+	});
+
+	it("renders CTA buttons for each tier", () => {
+		render(<PricingCards />);
+		expect(screen.getByText("Get Started Free")).toBeInTheDocument();
+		expect(screen.getByText("Start Free Trial")).toBeInTheDocument();
+		expect(screen.getByText("Contact Sales")).toBeInTheDocument();
+	});
+
+	it("has a billing toggle", () => {
+		render(<PricingCards />);
+		expect(screen.getByRole("switch")).toBeInTheDocument();
+		expect(screen.getByText("Monthly")).toBeInTheDocument();
+		expect(screen.getByText("Yearly")).toBeInTheDocument();
+	});
+
+	it("switches to yearly pricing when toggle is clicked", async () => {
+		const user = userEvent.setup();
+		render(<PricingCards />);
+
+		const toggle = screen.getByRole("switch");
+		await user.click(toggle);
+
+		expect(screen.getByText("$290")).toBeInTheDocument();
+		expect(screen.getByText(/Save 17%/)).toBeInTheDocument();
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<PricingCards className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/__tests__/pricing-cta.test.tsx
+++ b/src/components/pricing/__tests__/pricing-cta.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { PricingCta } from "../pricing-cta";
+
+describe("PricingCta", () => {
+	it("renders the section heading", () => {
+		render(<PricingCta />);
+		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Ready to get started?");
+	});
+
+	it("renders the description", () => {
+		render(<PricingCta />);
+		expect(screen.getByText(/Join thousands of teams/)).toBeInTheDocument();
+	});
+
+	it("renders two CTA buttons", () => {
+		render(<PricingCta />);
+		expect(screen.getByText("Start Free Trial")).toBeInTheDocument();
+		expect(screen.getByText("Talk to Sales")).toBeInTheDocument();
+	});
+
+	it("marks decorative gradient as aria-hidden", () => {
+		const { container } = render(<PricingCta />);
+		const decorative = container.querySelector("[aria-hidden='true']");
+		expect(decorative).toBeInTheDocument();
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<PricingCta className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/__tests__/pricing-faq.test.tsx
+++ b/src/components/pricing/__tests__/pricing-faq.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { PricingFaq } from "../pricing-faq";
+
+describe("PricingFaq", () => {
+	it("renders the section heading", () => {
+		render(<PricingFaq />);
+		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+			"Frequently asked questions",
+		);
+	});
+
+	it("renders 5 FAQ items", () => {
+		render(<PricingFaq />);
+		const buttons = screen.getAllByRole("button");
+		expect(buttons).toHaveLength(5);
+	});
+
+	it("renders FAQ questions", () => {
+		render(<PricingFaq />);
+		expect(screen.getByText("Can I switch plans at any time?")).toBeInTheDocument();
+		expect(screen.getByText("Is there a free trial for the Pro plan?")).toBeInTheDocument();
+	});
+
+	it("shows answer when question is clicked", async () => {
+		const user = userEvent.setup();
+		render(<PricingFaq />);
+
+		const firstButton = screen.getByText("Can I switch plans at any time?");
+		await user.click(firstButton);
+
+		expect(screen.getByText(/you can upgrade or downgrade/)).toBeInTheDocument();
+	});
+
+	it("has aria-expanded attribute on buttons", () => {
+		render(<PricingFaq />);
+		const buttons = screen.getAllByRole("button");
+		for (const button of buttons) {
+			expect(button).toHaveAttribute("aria-expanded", "false");
+		}
+	});
+
+	it("toggles aria-expanded when clicked", async () => {
+		const user = userEvent.setup();
+		render(<PricingFaq />);
+
+		const firstButton = screen.getByText("Can I switch plans at any time?");
+		expect(firstButton).toHaveAttribute("aria-expanded", "false");
+
+		await user.click(firstButton);
+		expect(firstButton).toHaveAttribute("aria-expanded", "true");
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<PricingFaq className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/__tests__/pricing-hero.test.tsx
+++ b/src/components/pricing/__tests__/pricing-hero.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { PricingHero } from "../pricing-hero";
+
+describe("PricingHero", () => {
+	it("renders the headline", () => {
+		render(<PricingHero />);
+		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(/Simple pricing for/);
+	});
+
+	it("renders the eyebrow label", () => {
+		render(<PricingHero />);
+		expect(screen.getByText("Pricing")).toBeInTheDocument();
+	});
+
+	it("renders the subheading", () => {
+		render(<PricingHero />);
+		expect(screen.getByText(/Start free and scale as you grow/)).toBeInTheDocument();
+	});
+
+	it("marks gradient shapes as decorative", () => {
+		const { container } = render(<PricingHero />);
+		const decorativeElements = container.querySelectorAll("[aria-hidden='true']");
+		expect(decorativeElements.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<PricingHero className="custom-class" />);
+		const section = container.querySelector("section");
+		expect(section).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/__tests__/scroll-progress.test.tsx
+++ b/src/components/pricing/__tests__/scroll-progress.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { createElement, forwardRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const motionPropKeys = new Set([
+	"initial",
+	"animate",
+	"exit",
+	"variants",
+	"transition",
+	"whileHover",
+	"whileTap",
+	"whileFocus",
+	"whileDrag",
+	"whileInView",
+	"viewport",
+	"layout",
+	"layoutId",
+	"onAnimationStart",
+	"onAnimationComplete",
+	"style",
+]);
+
+vi.mock("motion/react", () => ({
+	motion: new Proxy(
+		{},
+		{
+			get: (_target: unknown, prop: string) => {
+				const Comp = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+					const htmlProps: Record<string, unknown> = {};
+					for (const [key, value] of Object.entries(props)) {
+						if (!motionPropKeys.has(key)) {
+							htmlProps[key] = value;
+						}
+					}
+					return createElement(prop, { ...htmlProps, ref });
+				});
+				Comp.displayName = `motion.${prop}`;
+				return Comp;
+			},
+		},
+	),
+	useReducedMotion: () => false,
+	useScroll: () => ({ scrollYProgress: { get: () => 0, set: () => {} } }),
+	useTransform: (_value: unknown, _input: unknown, output: number[]) => ({
+		get: () => output?.[0] ?? 0,
+		set: () => {},
+	}),
+	useInView: () => true,
+	useMotionValue: (init: number) => ({ get: () => init, set: () => {} }),
+	animate: () => ({ stop: vi.fn() }),
+	AnimatePresence: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ScrollProgress } from "../scroll-progress";
+
+describe("ScrollProgress", () => {
+	it("renders a decorative progress bar", () => {
+		const { container } = render(<ScrollProgress />);
+		const bar = container.firstElementChild;
+		expect(bar).toBeInTheDocument();
+		expect(bar).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("accepts className prop", () => {
+		const { container } = render(<ScrollProgress className="custom-class" />);
+		const bar = container.firstElementChild;
+		expect(bar).toHaveClass("custom-class");
+	});
+});

--- a/src/components/pricing/feature-comparison.tsx
+++ b/src/components/pricing/feature-comparison.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import { MotionReveal } from "@/components/motion";
+import { Divider } from "@/components/ui/divider";
+import { cn } from "@/lib/utils";
+
+export type FeatureComparisonProps = {
+	className?: string;
+};
+
+type FeatureRow = {
+	feature: string;
+	starter: boolean | string;
+	pro: boolean | string;
+	enterprise: boolean | string;
+};
+
+const sections: { title: string; rows: FeatureRow[] }[] = [
+	{
+		title: "Core",
+		rows: [
+			{ feature: "Projects", starter: "5", pro: "Unlimited", enterprise: "Unlimited" },
+			{ feature: "Storage", starter: "1 GB", pro: "100 GB", enterprise: "Unlimited" },
+			{ feature: "API access", starter: true, pro: true, enterprise: true },
+			{ feature: "Webhooks", starter: false, pro: true, enterprise: true },
+		],
+	},
+	{
+		title: "Collaboration",
+		rows: [
+			{ feature: "Team members", starter: "1", pro: "10", enterprise: "Unlimited" },
+			{ feature: "Guest access", starter: false, pro: true, enterprise: true },
+			{ feature: "Role-based permissions", starter: false, pro: false, enterprise: true },
+		],
+	},
+	{
+		title: "Support",
+		rows: [
+			{ feature: "Community support", starter: true, pro: true, enterprise: true },
+			{ feature: "Priority email", starter: false, pro: true, enterprise: true },
+			{ feature: "Dedicated account manager", starter: false, pro: false, enterprise: true },
+			{ feature: "SLA", starter: false, pro: false, enterprise: true },
+		],
+	},
+];
+
+function CellValue({ value }: { value: boolean | string }) {
+	if (typeof value === "string") {
+		return <span className="text-sm font-medium text-foreground">{value}</span>;
+	}
+	if (value) {
+		return (
+			<svg
+				className="h-5 w-5 text-primary"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				strokeWidth={2.5}
+				aria-label="Included"
+			>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+			</svg>
+		);
+	}
+	return (
+		<svg
+			className="h-5 w-5 text-muted-foreground/40"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+			strokeWidth={2}
+			aria-label="Not included"
+		>
+			<path strokeLinecap="round" strokeLinejoin="round" d="M18 12H6" />
+		</svg>
+	);
+}
+
+export function FeatureComparison({ className }: FeatureComparisonProps) {
+	const shouldReduce = useReducedMotion();
+
+	return (
+		<section className={cn("mx-auto w-full max-w-5xl px-6 py-20 sm:px-8", className)}>
+			<MotionReveal direction="up" spring="gentle">
+				<h2 className="mb-4 text-center font-display text-3xl font-bold text-foreground sm:text-4xl">
+					Compare plans
+				</h2>
+				<p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
+					See which plan is right for your team with a detailed feature breakdown.
+				</p>
+			</MotionReveal>
+
+			{/* Table header */}
+			<div className="mb-2 grid grid-cols-4 gap-4 px-4">
+				<div />
+				<div className="text-center text-sm font-semibold text-foreground">Starter</div>
+				<div className="text-center text-sm font-semibold text-primary">Pro</div>
+				<div className="text-center text-sm font-semibold text-foreground">Enterprise</div>
+			</div>
+
+			{sections.map((section, sIdx) => (
+				<div key={section.title}>
+					{sIdx > 0 && <Divider className="my-6" />}
+					<MotionReveal direction="up" spring="gentle" delay={shouldReduce ? 0 : sIdx * 0.05}>
+						<h3 className="mb-3 px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+							{section.title}
+						</h3>
+					</MotionReveal>
+					{section.rows.map((row, rIdx) => (
+						<MotionReveal
+							key={row.feature}
+							direction="up"
+							spring="gentle"
+							delay={shouldReduce ? 0 : (sIdx * 4 + rIdx) * 0.03}
+						>
+							<div
+								className={cn(
+									"grid grid-cols-4 gap-4 rounded-lg px-4 py-3",
+									rIdx % 2 === 0 ? "bg-muted/30" : "bg-transparent",
+								)}
+							>
+								<div className="text-sm text-foreground">{row.feature}</div>
+								<div className="flex items-center justify-center">
+									<CellValue value={row.starter} />
+								</div>
+								<div className="flex items-center justify-center">
+									<CellValue value={row.pro} />
+								</div>
+								<div className="flex items-center justify-center">
+									<CellValue value={row.enterprise} />
+								</div>
+							</div>
+						</MotionReveal>
+					))}
+				</div>
+			))}
+		</section>
+	);
+}

--- a/src/components/pricing/logo-marquee.tsx
+++ b/src/components/pricing/logo-marquee.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+export type LogoMarqueeProps = {
+	className?: string;
+};
+
+const companies = [
+	"Vercel",
+	"Stripe",
+	"Linear",
+	"Notion",
+	"Figma",
+	"Shopify",
+	"Supabase",
+	"Railway",
+];
+
+export function LogoMarquee({ className }: LogoMarqueeProps) {
+	const shouldReduce = useReducedMotion();
+
+	return (
+		<section className={cn("border-y border-border bg-muted/30 py-8", className)}>
+			<p className="mb-6 text-center text-xs font-medium uppercase tracking-widest text-muted-foreground">
+				Trusted by teams at
+			</p>
+			<div className="relative overflow-hidden" role="marquee" aria-label="Companies that trust us">
+				{/* Fade edges */}
+				<div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-16 bg-gradient-to-r from-background to-transparent sm:w-24" />
+				<div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-16 bg-gradient-to-l from-background to-transparent sm:w-24" />
+
+				<div className={cn("flex gap-12 whitespace-nowrap", !shouldReduce && "animate-marquee")}>
+					{/* Primary set */}
+					{companies.map((name) => (
+						<span
+							key={name}
+							className="inline-flex items-center font-display text-lg font-semibold text-muted-foreground/60 select-none sm:text-xl"
+						>
+							{name}
+						</span>
+					))}
+					{/* Duplicate for seamless loop */}
+					<div aria-hidden="true" className="flex gap-12">
+						{companies.map((name) => (
+							<span
+								key={`dup-${name}`}
+								className="inline-flex items-center font-display text-lg font-semibold text-muted-foreground/60 select-none sm:text-xl"
+							>
+								{name}
+							</span>
+						))}
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/pricing/pricing-cards.tsx
+++ b/src/components/pricing/pricing-cards.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { useState } from "react";
+import { MotionItem, MotionStagger } from "@/components/motion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Toggle } from "@/components/ui/toggle";
+import { hoverLift, scaleInUp } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export type PricingCardsProps = {
+	className?: string;
+};
+
+type Tier = {
+	name: string;
+	monthlyPrice: string;
+	yearlyPrice: string;
+	description: string;
+	features: string[];
+	cta: string;
+	popular?: boolean;
+};
+
+const tiers: Tier[] = [
+	{
+		name: "Starter",
+		monthlyPrice: "$0",
+		yearlyPrice: "$0",
+		description: "For individuals and small projects getting started.",
+		features: ["5 projects", "1 GB storage", "Community support", "Basic analytics"],
+		cta: "Get Started Free",
+	},
+	{
+		name: "Pro",
+		monthlyPrice: "$29",
+		yearlyPrice: "$290",
+		description: "For growing teams that need more power and flexibility.",
+		features: [
+			"Unlimited projects",
+			"100 GB storage",
+			"Priority support",
+			"Advanced analytics",
+			"Custom domains",
+			"Team collaboration",
+		],
+		cta: "Start Free Trial",
+		popular: true,
+	},
+	{
+		name: "Enterprise",
+		monthlyPrice: "Custom",
+		yearlyPrice: "Custom",
+		description: "For organizations with advanced security and compliance needs.",
+		features: [
+			"Everything in Pro",
+			"Unlimited storage",
+			"24/7 dedicated support",
+			"SSO & SAML",
+			"Audit logs",
+			"Custom contracts",
+		],
+		cta: "Contact Sales",
+	},
+];
+
+export function PricingCards({ className }: PricingCardsProps) {
+	const shouldReduce = useReducedMotion();
+	const [isYearly, setIsYearly] = useState(false);
+
+	const interactionProps = shouldReduce ? {} : hoverLift;
+
+	return (
+		<section className={cn("mx-auto w-full max-w-6xl px-6 py-20 sm:px-8", className)}>
+			{/* Billing toggle */}
+			<div className="mb-12 flex items-center justify-center gap-3">
+				<span
+					className={cn(
+						"text-sm font-medium transition-colors",
+						!isYearly ? "text-foreground" : "text-muted-foreground",
+					)}
+				>
+					Monthly
+				</span>
+				<Toggle
+					checked={isYearly}
+					onCheckedChange={setIsYearly}
+					aria-label="Toggle yearly billing"
+				/>
+				<span
+					className={cn(
+						"text-sm font-medium transition-colors",
+						isYearly ? "text-foreground" : "text-muted-foreground",
+					)}
+				>
+					Yearly
+				</span>
+				{isYearly && (
+					<Badge variant="success" className="ml-1">
+						Save 17%
+					</Badge>
+				)}
+			</div>
+
+			{/* Cards */}
+			<MotionStagger stagger={0.15} className="grid gap-8 md:grid-cols-3">
+				{tiers.map((tier) => (
+					<MotionItem key={tier.name} variants={scaleInUp}>
+						<motion.div {...interactionProps}>
+							<Card
+								className={cn(
+									"relative flex h-full flex-col",
+									tier.popular && "border-primary shadow-lg ring-1 ring-primary/20",
+								)}
+							>
+								{tier.popular && (
+									<Badge variant="info" className="absolute -top-3 left-1/2 -translate-x-1/2">
+										Popular
+									</Badge>
+								)}
+								<CardHeader>
+									<CardTitle>{tier.name}</CardTitle>
+									<div className="mt-3">
+										<span className="font-display text-4xl font-bold text-foreground">
+											{isYearly ? tier.yearlyPrice : tier.monthlyPrice}
+										</span>
+										{tier.monthlyPrice !== "Custom" && (
+											<span className="text-sm text-muted-foreground">
+												/{isYearly ? "year" : "month"}
+											</span>
+										)}
+									</div>
+									<p className="mt-2 text-sm text-muted-foreground">{tier.description}</p>
+								</CardHeader>
+								<CardContent className="flex-1">
+									<ul className="space-y-3">
+										{tier.features.map((feature) => (
+											<li key={feature} className="flex items-start gap-2 text-sm text-foreground">
+												<svg
+													className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke="currentColor"
+													strokeWidth={2.5}
+													aria-hidden="true"
+												>
+													<path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+												</svg>
+												{feature}
+											</li>
+										))}
+									</ul>
+									<div className="mt-4 flex flex-wrap gap-1.5">
+										{tier.features.slice(0, 3).map((feature) => (
+											<Chip key={feature} size="sm">
+												{feature}
+											</Chip>
+										))}
+									</div>
+								</CardContent>
+								<CardFooter>
+									<Button
+										variant={tier.popular ? "primary" : "outline"}
+										className="w-full"
+										size="lg"
+									>
+										{tier.cta}
+									</Button>
+								</CardFooter>
+							</Card>
+						</motion.div>
+					</MotionItem>
+				))}
+			</MotionStagger>
+		</section>
+	);
+}

--- a/src/components/pricing/pricing-cta.tsx
+++ b/src/components/pricing/pricing-cta.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import { MotionReveal } from "@/components/motion";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type PricingCtaProps = {
+	className?: string;
+};
+
+export function PricingCta({ className }: PricingCtaProps) {
+	useReducedMotion();
+
+	return (
+		<section className={cn("relative overflow-hidden bg-muted/40 py-24", className)}>
+			{/* Decorative gradient */}
+			<div
+				className="pointer-events-none absolute inset-0 -z-10 opacity-30 dark:opacity-15"
+				style={{
+					background: "radial-gradient(ellipse at center, var(--primary) 0%, transparent 60%)",
+				}}
+				aria-hidden="true"
+			/>
+
+			<div className="mx-auto max-w-3xl px-6 text-center sm:px-8">
+				<MotionReveal direction="up" spring="gentle">
+					<h2 className="font-display text-3xl font-bold text-foreground sm:text-4xl lg:text-5xl">
+						Ready to get started?
+					</h2>
+					<p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
+						Join thousands of teams already using our platform. Start free today and upgrade as you
+						grow.
+					</p>
+					<div className="mt-8 flex flex-wrap items-center justify-center gap-4">
+						<Button size="lg">Start Free Trial</Button>
+						<Button variant="outline" size="lg">
+							Talk to Sales
+						</Button>
+					</div>
+				</MotionReveal>
+			</div>
+		</section>
+	);
+}

--- a/src/components/pricing/pricing-faq.tsx
+++ b/src/components/pricing/pricing-faq.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useState } from "react";
+import { MotionReveal } from "@/components/motion";
+import { reducedMotionTransition, springs } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export type PricingFaqProps = {
+	className?: string;
+};
+
+type FaqItem = {
+	question: string;
+	answer: string;
+};
+
+const faqs: FaqItem[] = [
+	{
+		question: "Can I switch plans at any time?",
+		answer:
+			"Yes, you can upgrade or downgrade your plan at any time. When upgrading, you'll be prorated for the remaining billing period. When downgrading, the new rate applies at the start of the next cycle.",
+	},
+	{
+		question: "Is there a free trial for the Pro plan?",
+		answer:
+			"Absolutely. Every Pro plan starts with a 14-day free trial with full access to all features. No credit card required to start.",
+	},
+	{
+		question: "What payment methods do you accept?",
+		answer:
+			"We accept all major credit cards (Visa, Mastercard, American Express), as well as PayPal and bank transfers for annual Enterprise plans.",
+	},
+	{
+		question: "What happens when I exceed my storage limit?",
+		answer:
+			"We'll notify you when you're approaching your limit. You won't lose any data — we'll simply pause new uploads until you upgrade your plan or free up space.",
+	},
+	{
+		question: "Do you offer discounts for nonprofits or education?",
+		answer:
+			"Yes, we offer a 50% discount for verified nonprofits and educational institutions. Contact our sales team to get set up.",
+	},
+];
+
+function FaqAccordionItem({
+	item,
+	isOpen,
+	onToggle,
+	shouldReduce,
+}: {
+	item: FaqItem;
+	isOpen: boolean;
+	onToggle: () => void;
+	shouldReduce: boolean | null;
+}) {
+	const transition = shouldReduce ? reducedMotionTransition : { ...springs.snappy, duration: 0.3 };
+
+	return (
+		<div className="border-b border-border">
+			<button
+				type="button"
+				onClick={onToggle}
+				className="flex w-full items-center justify-between py-5 text-left text-sm font-medium text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:text-base"
+				aria-expanded={isOpen}
+			>
+				{item.question}
+				<svg
+					className={cn(
+						"ml-4 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+						isOpen && "rotate-180",
+					)}
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+					strokeWidth={2}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+				</svg>
+			</button>
+			<AnimatePresence initial={false}>
+				{isOpen && (
+					<motion.div
+						initial={{ height: 0, opacity: 0 }}
+						animate={{ height: "auto", opacity: 1 }}
+						exit={{ height: 0, opacity: 0 }}
+						transition={transition}
+						className="overflow-hidden"
+					>
+						<p className="pb-5 text-sm text-muted-foreground leading-relaxed">{item.answer}</p>
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	);
+}
+
+export function PricingFaq({ className }: PricingFaqProps) {
+	const shouldReduce = useReducedMotion();
+	const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+	return (
+		<section className={cn("mx-auto w-full max-w-3xl px-6 py-20 sm:px-8", className)}>
+			<MotionReveal direction="up" spring="gentle">
+				<h2 className="mb-4 text-center font-display text-3xl font-bold text-foreground sm:text-4xl">
+					Frequently asked questions
+				</h2>
+				<p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
+					Everything you need to know about our pricing and plans.
+				</p>
+			</MotionReveal>
+
+			<div>
+				{faqs.map((faq, index) => (
+					<FaqAccordionItem
+						key={faq.question}
+						item={faq}
+						isOpen={openIndex === index}
+						onToggle={() => setOpenIndex(openIndex === index ? null : index)}
+						shouldReduce={shouldReduce}
+					/>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/src/components/pricing/pricing-hero.tsx
+++ b/src/components/pricing/pricing-hero.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { motion, useReducedMotion, useScroll, useTransform } from "motion/react";
+import { useRef } from "react";
+import { createStaggerContainer, fadeInUp, reducedMotionTransition, springs } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+export type PricingHeroProps = {
+	className?: string;
+};
+
+export function PricingHero({ className }: PricingHeroProps) {
+	const shouldReduce = useReducedMotion();
+	const sectionRef = useRef<HTMLElement>(null);
+	const { scrollYProgress } = useScroll({
+		target: sectionRef,
+		offset: ["start start", "end start"],
+	});
+
+	const shape1Y = useTransform(scrollYProgress, [0, 1], [0, -120]);
+	const shape2Y = useTransform(scrollYProgress, [0, 1], [0, -80]);
+	const shape3Y = useTransform(scrollYProgress, [0, 1], [0, -160]);
+
+	const containerVariants = shouldReduce
+		? { hidden: {}, visible: {} }
+		: createStaggerContainer(0.12, 0.1);
+
+	const itemTransition = shouldReduce ? reducedMotionTransition : springs.gentle;
+
+	return (
+		<section
+			ref={sectionRef}
+			className={cn("relative flex min-h-[70vh] items-center overflow-hidden", className)}
+		>
+			{/* Parallax gradient shapes — decorative */}
+			<motion.div
+				className="pointer-events-none absolute left-[10%] top-[20%] -z-10 h-[300px] w-[300px] rounded-full opacity-25 blur-3xl dark:opacity-15"
+				style={{
+					background: "radial-gradient(circle, var(--primary) 0%, transparent 70%)",
+					y: shouldReduce ? 0 : shape1Y,
+				}}
+				aria-hidden="true"
+			/>
+			<motion.div
+				className="pointer-events-none absolute right-[15%] top-[10%] -z-10 h-[250px] w-[250px] rounded-full opacity-20 blur-3xl dark:opacity-10"
+				style={{
+					background: "radial-gradient(circle, var(--accent) 0%, transparent 70%)",
+					y: shouldReduce ? 0 : shape2Y,
+				}}
+				aria-hidden="true"
+			/>
+			<motion.div
+				className="pointer-events-none absolute left-[50%] bottom-[10%] -z-10 h-[200px] w-[200px] rounded-full opacity-20 blur-3xl dark:opacity-10"
+				style={{
+					background: "radial-gradient(circle, var(--primary) 30%, var(--accent) 100%)",
+					y: shouldReduce ? 0 : shape3Y,
+				}}
+				aria-hidden="true"
+			/>
+
+			<div className="mx-auto w-full max-w-4xl px-6 py-24 text-center sm:px-8">
+				<motion.div
+					initial="hidden"
+					whileInView="visible"
+					viewport={{ once: true, amount: 0.2 }}
+					variants={containerVariants}
+				>
+					<motion.p
+						className="mb-4 text-sm font-medium uppercase tracking-widest text-primary"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						Pricing
+					</motion.p>
+
+					<motion.h1
+						className="font-display text-4xl font-bold leading-tight tracking-tight text-foreground sm:text-5xl lg:text-6xl"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						Simple pricing for <span className="text-primary">every team</span>
+					</motion.h1>
+
+					<motion.p
+						className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground sm:text-xl"
+						variants={fadeInUp}
+						transition={itemTransition}
+					>
+						Start free and scale as you grow. No hidden fees, no surprise charges. Just transparent
+						pricing that works for teams of any size.
+					</motion.p>
+				</motion.div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/pricing/scroll-progress.tsx
+++ b/src/components/pricing/scroll-progress.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { motion, useReducedMotion, useScroll } from "motion/react";
+import { cn } from "@/lib/utils";
+
+export type ScrollProgressProps = {
+	className?: string;
+};
+
+export function ScrollProgress({ className }: ScrollProgressProps) {
+	const shouldReduce = useReducedMotion();
+	const { scrollYProgress } = useScroll();
+
+	if (shouldReduce) return null;
+
+	return (
+		<motion.div
+			className={cn("fixed top-0 left-0 right-0 z-50 h-[3px] origin-left bg-primary", className)}
+			style={{ scaleX: scrollYProgress, transformOrigin: "left" }}
+			aria-hidden="true"
+		/>
+	);
+}

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -52,6 +52,11 @@ export const scaleIn: Variants = {
 	visible: { opacity: 1, scale: 1 },
 };
 
+export const scaleInUp: Variants = {
+	hidden: { opacity: 0, scale: 0.95, y: 16 },
+	visible: { opacity: 1, scale: 1, y: 0 },
+};
+
 // ─── Stagger helpers ────────────────────────────────────────────────
 
 /** Container variant that triggers staggered children. */


### PR DESCRIPTION
## Summary
- Add complete `/pricing` page with 7 animated section components: scroll progress bar, parallax hero, logo marquee, 3-tier pricing cards, feature comparison table, FAQ accordion with AnimatePresence, and CTA section
- Add `scaleInUp` variant preset to `src/lib/motion.ts` and `animate-marquee` CSS keyframe to `globals.css`
- Include 38 unit tests across 7 test files covering rendering, interactivity, and accessibility

Closes #97

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes with no warnings
- [x] All 38 new unit tests pass (`pnpm vitest run src/components/pricing/__tests__/`)
- [x] `pnpm build` succeeds with `/pricing` route in output
- [ ] Manual verification: visit `/pricing` in dev mode and check all sections render
- [ ] Verify reduced motion preference is respected (toggle in OS settings)
- [ ] Check responsive breakpoints at mobile (375px), tablet (768px), desktop (1280px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)