### PR TITLE
fix: resolve useScroll ref hydration error on /agency

### DIFF
--- a/src/components/agency/project-showcase.tsx
+++ b/src/components/agency/project-showcase.tsx
@@ -61,7 +61,7 @@ export function ProjectShowcase({ className }: ProjectShowcaseProps) {
 	}, []);
 
 	const { scrollYProgress } = useScroll({
-		target: outerRef,
+		...(isDesktop ? { target: outerRef } : {}),
 		offset: ["start start", "end end"],
 	});
 


### PR DESCRIPTION
## Summary
- Fix `useScroll` hydration error on `/agency` page by conditionally passing `target` ref only when the scroll container is in the DOM (`isDesktop` is true)

## Root Cause
`ProjectShowcase` called `useScroll({ target: outerRef })` unconditionally, but `outerRef` only attaches to a DOM element when `isDesktop` is true. On SSR/initial hydration (`isDesktop` = `false`), the ref is defined but unhydrated, causing Motion to throw.

## Fix
```diff
- target: outerRef,
+ ...(isDesktop ? { target: outerRef } : {}),
```

When `isDesktop` is `false`, `useScroll` gets no target and harmlessly defaults to window scroll.

## Why Tests Didn't Catch This
- Unit tests mock `useScroll` as a no-op — the hydration check is bypassed entirely
- No E2E tests exist for `/agency` (only `/showcase` is covered)
- This is a runtime-only hydration error that requires a real browser + React SSR

## Test Plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:unit` — 436 tests pass
- [x] `pnpm build` succeeds
- [ ] Manual verification: open `http://localhost:3000/agency` — no console errors

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)