### PR TITLE
fix: enforce full test suite in verify, pr-ready, and feature-orchestrator (#108)

### DIFF
--- a/.claude/agents/feature-orchestrator.md
+++ b/.claude/agents/feature-orchestrator.md
@@ -110,15 +110,19 @@ Utilities:   src/lib/<name>.ts
      disabled state, ref forwarding, className merging, accessibility attributes
    - Run: `pnpm test:unit`
 
-2. **E2E tests** (required for page-level changes):
+2. **E2E tests** (MANDATORY for page-level changes):
    - File: `tests/e2e/<feature>.spec.ts`
    - Framework: Playwright
+   - **MANDATORY**: When creating or modifying pages (`src/app/**/page.tsx`), you MUST create or update E2E tests in `tests/e2e/`. Verify the test file exists before proceeding to Phase 4.
    - Run: `pnpm test:e2e`
 
-3. **Visual regression tests** (recommended for new UI components):
+3. **Visual regression tests** (MANDATORY for new UI components):
    - File: `tests/visual/` (add to existing `components.spec.ts` or create new file)
    - Framework: Playwright screenshot tests
+   - **MANDATORY**: When creating new UI components in `src/components/ui/`, you MUST add visual regression tests in `tests/visual/components.spec.ts` (light + dark theme). Verify the test exists before proceeding to Phase 4.
    - Run: `pnpm test:visual`
+
+**Gate check before Phase 4**: Verify (1) unit tests exist and pass for all new/modified components, (2) e2e tests exist for any new/modified pages, (3) visual tests exist for any new components. Do NOT proceed to Phase 4 until all three are confirmed.
 
 ### Phase 4: Review
 
@@ -136,12 +140,15 @@ Utilities:   src/lib/<name>.ts
 
 ### Phase 5: Verify
 
-Run the full verification suite. All commands must pass:
+Run the full verification suite. All commands must pass (visual is soft-fail — report but don't block):
 
 ```bash
 pnpm typecheck        # TypeScript strict check
 pnpm lint             # Biome lint + format check (use pnpm lint:fix if fails)
 pnpm test:unit        # Unit tests
+pnpm test:integration # Integration tests
+pnpm test:e2e         # E2E tests
+pnpm test:visual      # Visual regression (report but don't block)
 pnpm build            # Production build
 ```
 

--- a/.claude/commands/pr-ready.md
+++ b/.claude/commands/pr-ready.md
@@ -1,6 +1,6 @@
 Prepare the current work for a pull request:
 
-1. Run full verification: typecheck, lint, unit tests, integration tests, build
+1. Run full verification: typecheck, lint, unit tests, integration tests, e2e tests, visual regression (soft-fail), build
 2. If anything fails, fix it
 3. Stage all changes: `git add -A`
 4. Create a descriptive commit message based on the changes

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -4,7 +4,11 @@ Run the full verification pipeline for this project:
 2. Lint and format check: `pnpm lint`
 3. Unit tests: `pnpm test:unit`
 4. Integration tests: `pnpm test:integration`
-5. Build check: `pnpm build`
+5. E2E tests: `pnpm test:e2e`
+6. Visual regression: `pnpm test:visual` (report results, do NOT block on failure)
+7. Build check: `pnpm build`
 
-Run each step. If any step fails, stop and report the failure with details.
-If all steps pass, report a summary of results.
+Steps 1-5 and 7 are blocking — stop and report on failure.
+Step 6 (visual) is informational — report pass/fail but continue regardless.
+
+If all blocking steps pass, report a summary of results including visual test status.


### PR DESCRIPTION
## Summary

- **`.claude/commands/verify.md`**: Added E2E tests, visual regression (soft-fail), and build check to the verification pipeline. Steps 1-5 and 7 are blocking; step 6 (visual) is informational only.
- **`.claude/commands/pr-ready.md`**: Updated step 1 to include e2e tests and visual regression (soft-fail) in the pre-PR verification list.
- **`.claude/agents/feature-orchestrator.md`**: 
  - Phase 3 (Test): Upgraded E2E tests and visual regression from "required"/"recommended" to **MANDATORY** with explicit gate checks before Phase 4.
  - Phase 5 (Verify): Added `pnpm test:integration`, `pnpm test:e2e`, and `pnpm test:visual` to the verification command block with visual as soft-fail.

## Test plan

- [x] Verify `verify.md` lists all 7 steps with correct blocking/soft-fail semantics
- [x] Verify `pr-ready.md` step 1 includes e2e and visual regression
- [x] Verify `feature-orchestrator.md` Phase 3 has MANDATORY labels and gate check paragraph
- [x] Verify `feature-orchestrator.md` Phase 5 includes all test commands

Closes #108