### PR TITLE
Add permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,6 +10,9 @@ concurrency:
   group: lighthouse-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions: { contents: read }` to test.yml and lighthouse.yml
- Both workflows previously ran with implicit all-access permissions
- All 5 CI workflows now follow least-privilege principle

Closes #117

## Test plan
- [x] test.yml has permissions block
- [x] lighthouse.yml has permissions block
- [x] Verify CI passes on this PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)